### PR TITLE
add arm64 build to workflows

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -37,9 +37,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           file: ./Dockerfile
           push: true


### PR DESCRIPTION
To enable feature request in https://github.com/bewcloud/bewcloud/issues/24, here is a PR to add arm64 build to workflows

References :
https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images