### PR TITLE
Update README.md on docker selfhost commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Or on your own machine:
 Download/copy [`docker-compose.yml`](/docker-compose.yml) and [`.env.sample`](/.env.sample) as `.env`.
 
 ```sh
-$ docker compose up # makes the app available at http://localhost:8000
-$ docker compose run website bash -c "cd /app && make migrate-db" # initializes/updates the database (only needs to be executed the first time and on any updates)
+$ docker compose up -d # makes the app available at http://localhost:8000
+$ docker compose run --rm website bash -c "cd /app && make migrate-db" # initializes/updates the database (only needs to be executed the first time and on any updates)
 ```
 
 Alternatively, check the [Development section below](#development).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Alternatively, check the [Development section below](#development).
 > [!IMPORTANT]
 > Even with signups disabled (`CONFIG_ALLOW_SIGNUPS="false"`), the first signup will work and become an admin.
 
+> [!NOTE]
+> `1993:1993` comes from deno's [docker image](https://github.com/denoland/deno_docker/blob/2abfe921484bdc79d11c7187a9d7b59537457c31/ubuntu.dockerfile#L20-L22) where `1993` is the default user id in it.
+
 ## Development
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or on your own machine:
 Download/copy [`docker-compose.yml`](/docker-compose.yml) and [`.env.sample`](/.env.sample) as `.env`.
 
 ```sh
-$ mkdir data-files
+$ mkdir data-files #  local directory for storing user-uploaded files
 $ chown -R 1993:1993 data-files # solves permission related issues
 $ docker compose up -d # makes the app available at http://localhost:8000
 $ docker compose run --rm website bash -c "cd /app && make migrate-db" # initializes/updates the database (only needs to be executed the first time and on any updates)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Or on your own machine:
 Download/copy [`docker-compose.yml`](/docker-compose.yml) and [`.env.sample`](/.env.sample) as `.env`.
 
 ```sh
+$ mkdir data-files
+$ chown -R 1993:1993 data-files # solves permission related issues
 $ docker compose up -d # makes the app available at http://localhost:8000
 $ docker compose run --rm website bash -c "cd /app && make migrate-db" # initializes/updates the database (only needs to be executed the first time and on any updates)
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     ports:
       - 127.0.0.1:8000:8000
     mem_limit: '256m'
-    user: '${UID}:${GID}' # if you run into issues with permissions for the data-files volume below, see other options at https://stackoverflow.com/a/56904335
     env_file:
       - path: .env
         required: true


### PR DESCRIPTION
Should solve #19 and #30 issues and closes #41

Also updated to start docker compose in detach mode (`-d`) and the database migrations command container will now remove itself after executing (`--rm`).