### PR TITLE
Custom Title, Description and Help Email

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,3 +20,7 @@ CONFIG_ENABLE_EMAILS="false" # if true, email verification will be required for 
 CONFIG_ENABLE_FOREVER_SIGNUP="true" # if true, all signups become active for 100 years
 # CONFIG_ALLOWED_COOKIE_DOMAINS="example.com,example.net" # can be set to allow more than the BASE_URL's domain for session cookies
 # CONFIG_SKIP_COOKIE_DOMAIN_SECURITY="true" # if true, the cookie domain will not be strictly set and checked against. This skipping slightly reduces security, but is usually necessary for reverse proxies like Cloudflare Tunnel.
+
+# CUSTOM_TITLE=""
+# CUSTOM_DESCRIPTION=""
+HELP_EMAIL="help@bewcloud.com" # if empty, "need help" sections will be disabled

--- a/islands/Settings.tsx
+++ b/islands/Settings.tsx
@@ -194,8 +194,12 @@ export default function Settings({ formData: formDataObject, error, notice, curr
 
         <h2 class='text-2xl mb-4 text-left px-4 max-w-screen-md mx-auto lg:min-w-96'>Delete your account</h2>
         <p class='text-left mt-2 mb-6 px-4 max-w-screen-md mx-auto lg:min-w-96'>
-          Deleting your account is instant and deletes all your data. If you need help, please{' '}
-          <a href={`mailto:${helpEmail}`}>reach out</a>.
+          Deleting your account is instant and deletes all your data.{' '}{helpEmail !== '' ? (
+            <span>
+              If you need help, please{' '}
+              <a href={`mailto:${helpEmail}`}>reach out</a>.
+            </span>
+          ) : null}
         </p>
 
         <form method='POST' class='mb-12'>

--- a/islands/Settings.tsx
+++ b/islands/Settings.tsx
@@ -196,9 +196,9 @@ export default function Settings({ formData: formDataObject, error, notice, curr
         <p class='text-left mt-2 mb-6 px-4 max-w-screen-md mx-auto lg:min-w-96'>
           Deleting your account is instant and deletes all your data. {helpEmail !== ''
             ? (
-              <span>
+              <>
                 If you need help, please <a href={`mailto:${helpEmail}`}>reach out</a>.
-              </span>
+              </>
             )
             : null}
         </p>

--- a/islands/Settings.tsx
+++ b/islands/Settings.tsx
@@ -194,12 +194,13 @@ export default function Settings({ formData: formDataObject, error, notice, curr
 
         <h2 class='text-2xl mb-4 text-left px-4 max-w-screen-md mx-auto lg:min-w-96'>Delete your account</h2>
         <p class='text-left mt-2 mb-6 px-4 max-w-screen-md mx-auto lg:min-w-96'>
-          Deleting your account is instant and deletes all your data.{' '}{helpEmail !== '' ? (
-            <span>
-              If you need help, please{' '}
-              <a href={`mailto:${helpEmail}`}>reach out</a>.
-            </span>
-          ) : null}
+          Deleting your account is instant and deletes all your data. {helpEmail !== ''
+            ? (
+              <span>
+                If you need help, please <a href={`mailto:${helpEmail}`}>reach out</a>.
+              </span>
+            )
+            : null}
         </p>
 
         <form method='POST' class='mb-12'>

--- a/lib/utils/misc.ts
+++ b/lib/utils/misc.ts
@@ -4,23 +4,23 @@ import { SupportedCurrencySymbol } from '/lib/types.ts';
 let BASE_URL = typeof window !== 'undefined' && window.location
   ? `${window.location.protocol}//${window.location.host}`
   : '';
-let CUSTOM_TITLE = '';
-let CUSTOM_DESCRIPTION = '';
-let HELP_EMAIL = '';
+let CUSTOM_TITLE = `bewCloud is a modern and simpler alternative to Nextcloud and ownCloud`;
+let CUSTOM_DESCRIPTION = `Have your files under your own control.`;
+let HELP_EMAIL = ``;
 
 if (typeof Deno !== 'undefined') {
   await import('std/dotenv/load.ts');
 
   BASE_URL = Deno.env.get('BASE_URL') || '';
 
-  CUSTOM_TITLE = Deno.env.get('CUSTOM_TITLE') || '';
-  CUSTOM_DESCRIPTION = Deno.env.get('CUSTOM_DESCRIPTION') || '';
-  HELP_EMAIL = Deno.env.get('HELP_EMAIL') || '';
+  CUSTOM_TITLE = Deno.env.get('CUSTOM_TITLE') || CUSTOM_TITLE;
+  CUSTOM_DESCRIPTION = Deno.env.get('CUSTOM_DESCRIPTION') || CUSTOM_DESCRIPTION;
+  HELP_EMAIL = Deno.env.get('HELP_EMAIL') || HELP_EMAIL;
 }
 
 export const baseUrl = BASE_URL || 'http://localhost:8000';
-export const defaultTitle = CUSTOM_TITLE || 'bewCloud is a modern and simpler alternative to Nextcloud and ownCloud';
-export const defaultDescription = CUSTOM_DESCRIPTION || `Have your files under your own control.`;
+export const defaultTitle = CUSTOM_TITLE;
+export const defaultDescription = CUSTOM_DESCRIPTION;
 export const helpEmail = HELP_EMAIL;
 
 export function isRunningLocally(request: Request): boolean {

--- a/lib/utils/misc.ts
+++ b/lib/utils/misc.ts
@@ -4,17 +4,24 @@ import { SupportedCurrencySymbol } from '/lib/types.ts';
 let BASE_URL = typeof window !== 'undefined' && window.location
   ? `${window.location.protocol}//${window.location.host}`
   : '';
+let CUSTOM_TITLE = '';
+let CUSTOM_DESCRIPTION = '';
+let HELP_EMAIL = '';
 
 if (typeof Deno !== 'undefined') {
   await import('std/dotenv/load.ts');
 
   BASE_URL = Deno.env.get('BASE_URL') || '';
+
+  CUSTOM_TITLE = Deno.env.get('CUSTOM_TITLE') || '';
+  CUSTOM_DESCRIPTION = Deno.env.get('CUSTOM_DESCRIPTION') || '';
+  HELP_EMAIL = Deno.env.get('HELP_EMAIL') || '';
 }
 
 export const baseUrl = BASE_URL || 'http://localhost:8000';
-export const defaultTitle = 'bewCloud is a modern and simpler alternative to Nextcloud and ownCloud';
-export const defaultDescription = `Have your files under your own control.`;
-export const helpEmail = 'help@bewcloud.com';
+export const defaultTitle = CUSTOM_TITLE || 'bewCloud is a modern and simpler alternative to Nextcloud and ownCloud';
+export const defaultDescription = CUSTOM_DESCRIPTION || `Have your files under your own control.`;
+export const helpEmail = HELP_EMAIL;
 
 export function isRunningLocally(request: Request): boolean {
   try {

--- a/lib/utils/misc.ts
+++ b/lib/utils/misc.ts
@@ -4,23 +4,23 @@ import { SupportedCurrencySymbol } from '/lib/types.ts';
 let BASE_URL = typeof window !== 'undefined' && window.location
   ? `${window.location.protocol}//${window.location.host}`
   : '';
-let CUSTOM_TITLE = `bewCloud is a modern and simpler alternative to Nextcloud and ownCloud`;
-let CUSTOM_DESCRIPTION = `Have your files under your own control.`;
-let HELP_EMAIL = ``;
+let CUSTOM_TITLE = '';
+let CUSTOM_DESCRIPTION = '';
+let HELP_EMAIL = '';
 
 if (typeof Deno !== 'undefined') {
   await import('std/dotenv/load.ts');
 
   BASE_URL = Deno.env.get('BASE_URL') || '';
 
-  CUSTOM_TITLE = Deno.env.get('CUSTOM_TITLE') || CUSTOM_TITLE;
-  CUSTOM_DESCRIPTION = Deno.env.get('CUSTOM_DESCRIPTION') || CUSTOM_DESCRIPTION;
-  HELP_EMAIL = Deno.env.get('HELP_EMAIL') || HELP_EMAIL;
+  CUSTOM_TITLE = Deno.env.get('CUSTOM_TITLE') || '';
+  CUSTOM_DESCRIPTION = Deno.env.get('CUSTOM_DESCRIPTION') || '';
+  HELP_EMAIL = Deno.env.get('HELP_EMAIL') || '';
 }
 
 export const baseUrl = BASE_URL || 'http://localhost:8000';
-export const defaultTitle = CUSTOM_TITLE;
-export const defaultDescription = CUSTOM_DESCRIPTION;
+export const defaultTitle = CUSTOM_TITLE || 'bewCloud is a modern and simpler alternative to Nextcloud and ownCloud';
+export const defaultDescription = CUSTOM_DESCRIPTION || `Have your files under your own control.`;
 export const helpEmail = HELP_EMAIL;
 
 export function isRunningLocally(request: Request): boolean {

--- a/routes/login.tsx
+++ b/routes/login.tsx
@@ -173,13 +173,19 @@ export default function Login({ data }: PageProps<Data, FreshContextState>) {
           </strong>.
         </p>
 
-        <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
-        <p class='text-center mt-2 mb-6'>
-          If you're having any issues or have any questions,{' '}
-          <strong>
-            <a href={`mailto:${helpEmail}`}>please reach out</a>
-          </strong>.
-        </p>
+        {helpEmail !== ''
+          ? (
+            <section>
+              <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
+              <p class='text-center mt-2 mb-6'>
+                If you're having any issues or have any questions,{' '}
+                <strong>
+                  <a href={`mailto:${helpEmail}`}>please reach out</a>
+                </strong>.
+              </p>
+            </section>
+          )
+          : null}
       </section>
     </main>
   );

--- a/routes/login.tsx
+++ b/routes/login.tsx
@@ -175,7 +175,7 @@ export default function Login({ data }: PageProps<Data, FreshContextState>) {
 
         {helpEmail !== ''
           ? (
-            <section>
+            <>
               <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
               <p class='text-center mt-2 mb-6'>
                 If you're having any issues or have any questions,{' '}
@@ -183,7 +183,7 @@ export default function Login({ data }: PageProps<Data, FreshContextState>) {
                   <a href={`mailto:${helpEmail}`}>please reach out</a>
                 </strong>.
               </p>
-            </section>
+            </>
           )
           : null}
       </section>

--- a/routes/signup.tsx
+++ b/routes/signup.tsx
@@ -146,7 +146,7 @@ export default function Signup({ data }: PageProps<Data, FreshContextState>) {
 
         {helpEmail !== ''
           ? (
-            <section>
+            <>
               <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
               <p class='text-center mt-2 mb-6'>
                 If you're having any issues or have any questions,{' '}
@@ -154,7 +154,7 @@ export default function Signup({ data }: PageProps<Data, FreshContextState>) {
                   <a href={`mailto:${helpEmail}`}>please reach out</a>
                 </strong>.
               </p>
-            </section>
+            </>
           )
           : null}
       </section>

--- a/routes/signup.tsx
+++ b/routes/signup.tsx
@@ -144,13 +144,19 @@ export default function Signup({ data }: PageProps<Data, FreshContextState>) {
           </strong>.
         </p>
 
-        <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
-        <p class='text-center mt-2 mb-6'>
-          If you're having any issues or have any questions,{' '}
-          <strong>
-            <a href={`mailto:${helpEmail}`}>please reach out</a>
-          </strong>.
-        </p>
+        {helpEmail !== ''
+          ? (
+            <section>
+              <h2 class='text-2xl mb-4 text-center'>Need help?</h2>
+              <p class='text-center mt-2 mb-6'>
+                If you're having any issues or have any questions,{' '}
+                <strong>
+                  <a href={`mailto:${helpEmail}`}>please reach out</a>
+                </strong>.
+              </p>
+            </section>
+          )
+          : null}
       </section>
     </main>
   );


### PR DESCRIPTION
Hello, I missed possibility to change title, description and hide help text on my self-hosted instance.

These changes are quite small and I don't think that will be a problem.

Thank you for creating bewCloud (crying in broken 4 owncloud instances).

## Use cases
User has an instance that is managed by third-party and mailto link is to that third-party or just maintainer wants to hide it.
Maintainer of instance want to change title and description for his private cloud instance.