### PR TITLE
Public File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@ If you're looking for the mobile app, it's at [`bewcloud-mobile`](https://github
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/bewcloud/bewcloud)
 
+[![Buy managed cloud (1 year)](https://img.shields.io/badge/Buy%20managed%20cloud%20(1%20year)-51a4fb?style=for-the-badge)](https://buy.stripe.com/eVa01HgQk0Ap0eseVz)
+
+[![Buy managed cloud (1 month)](https://img.shields.io/badge/Buy%20managed%20cloud%20(1%20month)-51a4fb?style=for-the-badge)](https://buy.stripe.com/fZu8wOb5RfIydj56FA1gs0J)
+
 Or on your own machine:
 
 Download/copy [`docker-compose.yml`](/docker-compose.yml), [`.env.sample`](/.env.sample) as `.env`, and [`bewcloud.config.sample.ts`](/bewcloud.config.sample.ts) as `bewcloud.config.ts`.
 
+> [!NOTE]
+> `1993:1993` below comes from deno's [docker image](https://github.com/denoland/deno_docker/blob/2abfe921484bdc79d11c7187a9d7b59537457c31/ubuntu.dockerfile#L20-L22) where `1993` is the default user id in it. It might change in the future since I don't control it.
+
 ```sh
-$ mkdir data-files #  local directory for storing user-uploaded files
+$ mkdir data-files # local directory for storing user-uploaded files
 $ sudo chown -R 1993:1993 data-files # solves permission-related issues in the container with uploading files
 $ docker compose up -d # makes the app available at http://localhost:8000
 $ docker compose run --rm website bash -c "cd /app && make migrate-db" # initializes/updates the database (only needs to be executed the first time and on any data updates)
@@ -29,9 +36,6 @@ Alternatively, check the [Development section below](#development).
 
 > [!IMPORTANT]
 > Even with signups disabled (`config.auth.allowSignups=false`), the first signup will work and become an admin.
-
-> [!NOTE]
-> `1993:1993` above comes from deno's [docker image](https://github.com/denoland/deno_docker/blob/2abfe921484bdc79d11c7187a9d7b59537457c31/ubuntu.dockerfile#L20-L22) where `1993` is the default user id in it. It might change in the future since I don't control it.
 
 ## Sponsors
 
@@ -91,9 +95,9 @@ Just push to the `main` branch.
 
 My focus was to get me to replace Nextcloud for me and my family ASAP, and it turns out it's not easy to do it all in a single, installable _thing_, so I focused on the Files UI, sync, and sharing, since [Radicale](https://radicale.org/v3.html) solved my other issues better than my own solution (and it's already _very_ efficient).
 
-## How does file sharing work?
+## How does private file sharing work?
 
-[Check this PR for advanced sharing with internal and external users, with read and write access that was being done and almost working](https://github.com/bewcloud/bewcloud/pull/4). I ditched all that complexity for simply using [symlinks](https://en.wikipedia.org/wiki/Symbolic_link), as it served my use case (I have multiple data backups and trust the people I provide accounts to, with the symlinks).
+Public file sharing is now possible since [v2.2.0](https://github.com/bewcloud/bewcloud/releases/tag/v2.2.0). [Check this PR for advanced sharing with internal and external users, with read and write access that was being done and almost working](https://github.com/bewcloud/bewcloud/pull/4). I ditched all that complexity for simply using [symlinks](https://en.wikipedia.org/wiki/Symbolic_link) for internal sharing, as it served my use case (I have multiple data backups and trust the people I provide accounts to, with the symlinks).
 
 You can simply `ln -s /<absolute-path-to-data-files>/<owner-user-id>/<directory-to-share> /<absolute-path-to-data-files>/<user-id-to-share-with>/` to create a shared directory between two users, and the same directory can have different names, now.
 

--- a/bewcloud.config.sample.ts
+++ b/bewcloud.config.sample.ts
@@ -13,6 +13,7 @@ const config: PartialDeep<Config> = {
   },
   // files: {
   //   rootPath: 'data-files',
+  //   allowPublicSharing: false, // If true, public file sharing will be allowed (still requires a user to enable sharing for a given file or directory)
   // },
   // core: {
   //   enabledApps: ['news', 'notes', 'photos', 'expenses'], // dashboard and files cannot be disabled

--- a/components/auth/MultiFactorAuthVerifyForm.tsx
+++ b/components/auth/MultiFactorAuthVerifyForm.tsx
@@ -28,9 +28,9 @@ export default function MultiFactorAuthVerifyForm(
 
       {error
         ? (
-          <section class='bg-red-900 border border-red-700 text-red-100 px-4 py-3 rounded relative mb-4'>
-            <strong class='font-bold'>{error.title}:</strong>
-            <span class='block sm:inline'>{error.message}</span>
+          <section class='notification-error'>
+            <h3>{error.title}</h3>
+            <p>{error.message}</p>
           </section>
         )
         : null}

--- a/components/files/CreateShareModal.tsx
+++ b/components/files/CreateShareModal.tsx
@@ -1,0 +1,67 @@
+import { useSignal } from '@preact/signals';
+
+interface CreateShareModalProps {
+  isOpen: boolean;
+  filePath: string;
+  password?: string;
+  onClickSave: (filePath: string, password?: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function CreateShareModal(
+  { isOpen, filePath, password, onClickSave, onClose }: CreateShareModalProps,
+) {
+  const newPassword = useSignal<string>(password || '');
+
+  return (
+    <>
+      <section
+        class={`fixed ${isOpen ? 'block' : 'hidden'} z-40 w-screen h-screen inset-0 bg-gray-900 bg-opacity-60`}
+      >
+      </section>
+
+      <section
+        class={`fixed ${
+          isOpen ? 'block' : 'hidden'
+        } z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 bg-slate-600 text-white rounded-md px-8 py-6 drop-shadow-lg overflow-y-scroll max-h-[80%]`}
+      >
+        <h1 class='text-2xl font-semibold my-5'>Create New Public Share Link</h1>
+        <section class='py-5 my-2 border-y border-slate-500'>
+          <fieldset class='block mb-2'>
+            <label class='text-slate-300 block pb-1' for='password'>Password</label>
+            <input
+              class='input-field'
+              type='password'
+              name='password'
+              id='password'
+              value={newPassword.value}
+              onInput={(event) => {
+                newPassword.value = event.currentTarget.value;
+              }}
+              autocomplete='off'
+            />
+          </fieldset>
+        </section>
+        <footer class='flex justify-between'>
+          <button
+            class='px-5 py-2 bg-slate-600 hover:bg-slate-500 text-white cursor-pointer rounded-md'
+            onClick={() => {
+              onClickSave(filePath, newPassword.peek());
+              newPassword.value = '';
+            }}
+            type='button'
+          >
+            Create
+          </button>
+          <button
+            class='px-5 py-2 bg-slate-600 hover:bg-slate-500 text-white cursor-pointer rounded-md'
+            onClick={() => onClose()}
+            type='button'
+          >
+            Close
+          </button>
+        </footer>
+      </section>
+    </>
+  );
+}

--- a/components/files/FilesBreadcrumb.tsx
+++ b/components/files/FilesBreadcrumb.tsx
@@ -2,21 +2,23 @@ interface FilesBreadcrumbProps {
   path: string;
   isShowingNotes?: boolean;
   isShowingPhotos?: boolean;
+  fileShareId?: string;
 }
 
-export default function FilesBreadcrumb({ path, isShowingNotes, isShowingPhotos }: FilesBreadcrumbProps) {
-  let routePath = 'files';
+export default function FilesBreadcrumb({ path, isShowingNotes, isShowingPhotos, fileShareId }: FilesBreadcrumbProps) {
+  let routePath = fileShareId ? `file-share/${fileShareId}` : 'files';
   let rootPath = '/';
+  let itemPluralLabel = 'files';
 
   if (isShowingNotes) {
     routePath = 'notes';
+    itemPluralLabel = 'notes';
     rootPath = '/Notes/';
   } else if (isShowingPhotos) {
     routePath = 'photos';
+    itemPluralLabel = 'photos';
     rootPath = '/Photos/';
   }
-
-  const itemPluralLabel = routePath;
 
   if (path === rootPath) {
     return (
@@ -30,7 +32,7 @@ export default function FilesBreadcrumb({ path, isShowingNotes, isShowingPhotos 
 
   return (
     <h3 class='text-base font-semibold text-white whitespace-nowrap mr-2'>
-      {!isShowingNotes && !isShowingPhotos ? <a href={`/files?path=/`}>All files</a> : null}
+      {!isShowingNotes && !isShowingPhotos ? <a href={`/${routePath}?path=/`}>All files</a> : null}
       {isShowingNotes ? <a href={`/notes?path=/Notes/`}>All notes</a> : null}
       {isShowingPhotos ? <a href={`/photos?path=/Photos/`}>All photos</a> : null}
       {pathParts.map((part, index) => {
@@ -57,7 +59,9 @@ export default function FilesBreadcrumb({ path, isShowingNotes, isShowingPhotos 
         return (
           <>
             <span class='ml-2 text-xs'>/</span>
-            <a href={`/${routePath}?path=/${fullPathForPart.join('/')}/`} class='ml-2'>{decodeURIComponent(part)}</a>
+            <a href={`/${routePath}?path=/${encodeURIComponent(fullPathForPart.join('/'))}/`} class='ml-2'>
+              {decodeURIComponent(part)}
+            </a>
           </>
         );
       })}

--- a/components/files/ListPhotos.tsx
+++ b/components/files/ListPhotos.tsx
@@ -58,7 +58,7 @@ export default function ListFiles(
               <tr class='bg-slate-700 hover:bg-slate-600 group'>
                 <td class='flex gap-3 px-6 py-4'>
                   <a
-                    href={`/${routePath}?path=${fullPath}`}
+                    href={`/${routePath}?path=${encodeURIComponent(fullPath)}`}
                     class='flex items-center font-normal text-white'
                   >
                     <img
@@ -135,7 +135,9 @@ export default function ListFiles(
             <tr class='bg-slate-700 hover:bg-slate-600 group'>
               <td class='flex gap-3 px-6 py-4'>
                 <a
-                  href={`/${routePath}/open/${file.file_name}?path=${file.parent_path}`}
+                  href={`/${routePath}/open/${encodeURIComponent(file.file_name)}?path=${
+                    encodeURIComponent(file.parent_path)
+                  }`}
                   class='flex items-center font-normal text-white'
                   target='_blank'
                   rel='noopener noreferrer'

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -47,11 +47,12 @@ interface MainFilesProps {
   initialFiles: DirectoryFile[];
   initialPath: string;
   baseUrl: string;
+  isFileSharingAllowed: boolean;
   fileShareId?: string;
 }
 
 export default function MainFiles(
-  { initialDirectories, initialFiles, initialPath, baseUrl, fileShareId }: MainFilesProps,
+  { initialDirectories, initialFiles, initialPath, baseUrl, isFileSharingAllowed, fileShareId }: MainFilesProps,
 ) {
   const isAdding = useSignal<boolean>(false);
   const isUploading = useSignal<boolean>(false);
@@ -774,8 +775,8 @@ export default function MainFiles(
           onClickOpenMoveFile={onClickOpenMoveFile}
           onClickDeleteDirectory={onClickDeleteDirectory}
           onClickDeleteFile={onClickDeleteFile}
-          onClickCreateShare={onClickCreateShare}
-          onClickOpenManageShare={onClickOpenManageShare}
+          onClickCreateShare={isFileSharingAllowed ? onClickCreateShare : undefined}
+          onClickOpenManageShare={isFileSharingAllowed ? onClickOpenManageShare : undefined}
           fileShareId={fileShareId}
         />
 
@@ -860,7 +861,7 @@ export default function MainFiles(
         )
         : null}
 
-      {!fileShareId
+      {!fileShareId && isFileSharingAllowed
         ? (
           <CreateShareModal
             isOpen={createShareModal.value?.isOpen || false}
@@ -872,7 +873,7 @@ export default function MainFiles(
         )
         : null}
 
-      {!fileShareId
+      {!fileShareId && isFileSharingAllowed
         ? (
           <ManageShareModal
             baseUrl={baseUrl}

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -21,21 +21,38 @@ import {
   RequestBody as DeleteDirectoryRequestBody,
   ResponseBody as DeleteDirectoryResponseBody,
 } from '/routes/api/files/delete-directory.tsx';
+import {
+  RequestBody as CreateShareRequestBody,
+  ResponseBody as CreateShareResponseBody,
+} from '/routes/api/files/create-share.tsx';
+import {
+  RequestBody as UpdateShareRequestBody,
+  ResponseBody as UpdateShareResponseBody,
+} from '/routes/api/files/update-share.tsx';
+import {
+  RequestBody as DeleteShareRequestBody,
+  ResponseBody as DeleteShareResponseBody,
+} from '/routes/api/files/delete-share.tsx';
 import SearchFiles from './SearchFiles.tsx';
 import ListFiles from './ListFiles.tsx';
 import FilesBreadcrumb from './FilesBreadcrumb.tsx';
 import CreateDirectoryModal from './CreateDirectoryModal.tsx';
 import RenameDirectoryOrFileModal from './RenameDirectoryOrFileModal.tsx';
 import MoveDirectoryOrFileModal from './MoveDirectoryOrFileModal.tsx';
+import CreateShareModal from './CreateShareModal.tsx';
+import ManageShareModal from './ManageShareModal.tsx';
 
 interface MainFilesProps {
   initialDirectories: Directory[];
   initialFiles: DirectoryFile[];
   initialPath: string;
   baseUrl: string;
+  fileShareId?: string;
 }
 
-export default function MainFiles({ initialDirectories, initialFiles, initialPath, baseUrl }: MainFilesProps) {
+export default function MainFiles(
+  { initialDirectories, initialFiles, initialPath, baseUrl, fileShareId }: MainFilesProps,
+) {
   const isAdding = useSignal<boolean>(false);
   const isUploading = useSignal<boolean>(false);
   const isDeleting = useSignal<boolean>(false);
@@ -56,6 +73,8 @@ export default function MainFiles({ initialDirectories, initialFiles, initialPat
   const moveDirectoryOrFileModal = useSignal<
     { isOpen: boolean; isDirectory: boolean; path: string; name: string } | null
   >(null);
+  const createShareModal = useSignal<{ isOpen: boolean; filePath: string; password?: string } | null>(null);
+  const manageShareModal = useSignal<{ isOpen: boolean; fileShareId: string } | null>(null);
 
   function onClickUploadFile(uploadDirectory = false) {
     const fileInput = document.createElement('input');
@@ -483,12 +502,150 @@ export default function MainFiles({ initialDirectories, initialFiles, initialPat
     }
   }
 
+  function onClickCreateShare(filePath: string) {
+    if (createShareModal.value?.isOpen) {
+      createShareModal.value = null;
+      return;
+    }
+
+    createShareModal.value = {
+      isOpen: true,
+      filePath,
+    };
+  }
+
+  async function onClickSaveFileShare(filePath: string, password?: string) {
+    if (isAdding.value) {
+      return;
+    }
+
+    if (!filePath) {
+      return;
+    }
+
+    isAdding.value = true;
+
+    try {
+      const requestBody: CreateShareRequestBody = {
+        pathInView: path.value,
+        filePath,
+        password,
+      };
+      const response = await fetch(`/api/files/create-share`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+      const result = await response.json() as CreateShareResponseBody;
+
+      if (!result.success) {
+        throw new Error('Failed to create share!');
+      }
+
+      directories.value = [...result.newDirectories];
+      files.value = [...result.newFiles];
+
+      createShareModal.value = null;
+
+      onClickOpenManageShare(result.createdFileShareId);
+    } catch (error) {
+      console.error(error);
+    }
+
+    isAdding.value = false;
+  }
+
+  function onClickCloseFileShare() {
+    createShareModal.value = null;
+  }
+
+  function onClickOpenManageShare(fileShareId: string) {
+    manageShareModal.value = {
+      isOpen: true,
+      fileShareId,
+    };
+  }
+
+  async function onClickUpdateFileShare(fileShareId: string, password?: string) {
+    if (isUpdating.value) {
+      return;
+    }
+
+    if (!fileShareId) {
+      return;
+    }
+
+    isUpdating.value = true;
+
+    try {
+      const requestBody: UpdateShareRequestBody = {
+        pathInView: path.value,
+        fileShareId,
+        password,
+      };
+      const response = await fetch(`/api/files/update-share`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+      const result = await response.json() as UpdateShareResponseBody;
+
+      if (!result.success) {
+        throw new Error('Failed to update share!');
+      }
+
+      directories.value = [...result.newDirectories];
+      files.value = [...result.newFiles];
+
+      manageShareModal.value = null;
+    } catch (error) {
+      console.error(error);
+    }
+
+    isUpdating.value = false;
+  }
+
+  function onClickCloseManageShare() {
+    manageShareModal.value = null;
+  }
+
+  async function onClickDeleteFileShare(fileShareId: string) {
+    if (!fileShareId || isDeleting.value || !confirm('Are you sure you want to delete this public share link?')) {
+      return;
+    }
+
+    isDeleting.value = true;
+
+    try {
+      const requestBody: DeleteShareRequestBody = {
+        pathInView: path.value,
+        fileShareId,
+      };
+      const response = await fetch(`/api/files/delete-share`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+      const result = await response.json() as DeleteShareResponseBody;
+
+      if (!result.success) {
+        throw new Error('Failed to delete file share!');
+      }
+
+      directories.value = [...result.newDirectories];
+      files.value = [...result.newFiles];
+
+      manageShareModal.value = null;
+    } catch (error) {
+      console.error(error);
+    }
+
+    isDeleting.value = false;
+  }
+
   return (
     <>
       <section class='flex flex-row items-center justify-between mb-4'>
         <section class='relative inline-block text-left mr-2'>
           <section class='flex flex-row items-center justify-start'>
-            <SearchFiles />
+            {!fileShareId ? <SearchFiles /> : null}
 
             {isAnyItemChosen
               ? (
@@ -539,63 +696,67 @@ export default function MainFiles({ initialDirectories, initialFiles, initialPat
         </section>
 
         <section class='flex items-center justify-end'>
-          <FilesBreadcrumb path={path.value} />
+          <FilesBreadcrumb path={path.value} fileShareId={fileShareId} />
 
-          <section class='relative inline-block text-left ml-2'>
-            <div>
-              <button
-                class='inline-block justify-center gap-x-1.5 rounded-md bg-[#51A4FB] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-400 ml-2'
-                type='button'
-                title='Add new file or directory'
-                id='new-button'
-                aria-expanded='true'
-                aria-haspopup='true'
-                onClick={() => toggleNewOptionsDropdown()}
-              >
-                <img
-                  src='/images/add.svg'
-                  alt='Add new file or directory'
-                  class={`white ${isAdding.value || isUploading.value ? 'animate-spin' : ''}`}
-                  width={20}
-                  height={20}
-                />
-              </button>
-            </div>
+          {!fileShareId
+            ? (
+              <section class='relative inline-block text-left ml-2'>
+                <div>
+                  <button
+                    class='inline-block justify-center gap-x-1.5 rounded-md bg-[#51A4FB] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-400 ml-2'
+                    type='button'
+                    title='Add new file or directory'
+                    id='new-button'
+                    aria-expanded='true'
+                    aria-haspopup='true'
+                    onClick={() => toggleNewOptionsDropdown()}
+                  >
+                    <img
+                      src='/images/add.svg'
+                      alt='Add new file or directory'
+                      class={`white ${isAdding.value || isUploading.value ? 'animate-spin' : ''}`}
+                      width={20}
+                      height={20}
+                    />
+                  </button>
+                </div>
 
-            <div
-              class={`absolute right-0 z-10 mt-2 w-44 origin-top-right rounded-md bg-slate-700 shadow-lg ring-1 ring-black ring-opacity-15 focus:outline-none ${
-                !areNewOptionsOpen.value ? 'hidden' : ''
-              }`}
-              role='menu'
-              aria-orientation='vertical'
-              aria-labelledby='new-button'
-              tabindex={-1}
-            >
-              <div class='py-1'>
-                <button
-                  class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
-                  onClick={() => onClickUploadFile()}
-                  type='button'
+                <div
+                  class={`absolute right-0 z-10 mt-2 w-44 origin-top-right rounded-md bg-slate-700 shadow-lg ring-1 ring-black ring-opacity-15 focus:outline-none ${
+                    !areNewOptionsOpen.value ? 'hidden' : ''
+                  }`}
+                  role='menu'
+                  aria-orientation='vertical'
+                  aria-labelledby='new-button'
+                  tabindex={-1}
                 >
-                  Upload Files
-                </button>
-                <button
-                  class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
-                  onClick={() => onClickUploadFile(true)}
-                  type='button'
-                >
-                  Upload Directory
-                </button>
-                <button
-                  class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
-                  onClick={() => onClickCreateDirectory()}
-                  type='button'
-                >
-                  New Directory
-                </button>
-              </div>
-            </div>
-          </section>
+                  <div class='py-1'>
+                    <button
+                      class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
+                      onClick={() => onClickUploadFile()}
+                      type='button'
+                    >
+                      Upload Files
+                    </button>
+                    <button
+                      class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
+                      onClick={() => onClickUploadFile(true)}
+                      type='button'
+                    >
+                      Upload Directory
+                    </button>
+                    <button
+                      class={`text-white block px-4 py-2 text-sm w-full text-left hover:bg-slate-600`}
+                      onClick={() => onClickCreateDirectory()}
+                      type='button'
+                    >
+                      New Directory
+                    </button>
+                  </div>
+                </div>
+              </section>
+            )
+            : null}
         </section>
       </section>
 
@@ -613,6 +774,9 @@ export default function MainFiles({ initialDirectories, initialFiles, initialPat
           onClickOpenMoveFile={onClickOpenMoveFile}
           onClickDeleteDirectory={onClickDeleteDirectory}
           onClickDeleteFile={onClickDeleteFile}
+          onClickCreateShare={onClickCreateShare}
+          onClickOpenManageShare={onClickOpenManageShare}
+          fileShareId={fileShareId}
         />
 
         <span
@@ -650,33 +814,76 @@ export default function MainFiles({ initialDirectories, initialFiles, initialPat
         </span>
       </section>
 
-      <section class='flex flex-row items-center justify-start my-12'>
-        <span class='font-semibold'>WebDav URL:</span>{' '}
-        <code class='bg-slate-600 mx-2 px-2 py-1 rounded-md'>{baseUrl}/dav</code>
-      </section>
+      {!fileShareId
+        ? (
+          <section class='flex flex-row items-center justify-start my-12'>
+            <span class='font-semibold'>WebDav URL:</span>{' '}
+            <code class='bg-slate-600 mx-2 px-2 py-1 rounded-md'>{baseUrl}/dav</code>
+          </section>
+        )
+        : null}
 
-      <CreateDirectoryModal
-        isOpen={isNewDirectoryModalOpen.value}
-        onClickSave={onClickSaveDirectory}
-        onClose={onCloseCreateDirectory}
-      />
+      {!fileShareId
+        ? (
+          <CreateDirectoryModal
+            isOpen={isNewDirectoryModalOpen.value}
+            onClickSave={onClickSaveDirectory}
+            onClose={onCloseCreateDirectory}
+          />
+        )
+        : null}
 
-      <RenameDirectoryOrFileModal
-        isOpen={renameDirectoryOrFileModal.value?.isOpen || false}
-        isDirectory={renameDirectoryOrFileModal.value?.isDirectory || false}
-        initialName={renameDirectoryOrFileModal.value?.name || ''}
-        onClickSave={renameDirectoryOrFileModal.value?.isDirectory ? onClickSaveRenameDirectory : onClickSaveRenameFile}
-        onClose={onClickCloseRename}
-      />
+      {!fileShareId
+        ? (
+          <RenameDirectoryOrFileModal
+            isOpen={renameDirectoryOrFileModal.value?.isOpen || false}
+            isDirectory={renameDirectoryOrFileModal.value?.isDirectory || false}
+            initialName={renameDirectoryOrFileModal.value?.name || ''}
+            onClickSave={renameDirectoryOrFileModal.value?.isDirectory
+              ? onClickSaveRenameDirectory
+              : onClickSaveRenameFile}
+            onClose={onClickCloseRename}
+          />
+        )
+        : null}
 
-      <MoveDirectoryOrFileModal
-        isOpen={moveDirectoryOrFileModal.value?.isOpen || false}
-        isDirectory={moveDirectoryOrFileModal.value?.isDirectory || false}
-        initialPath={moveDirectoryOrFileModal.value?.path || ''}
-        name={moveDirectoryOrFileModal.value?.name || ''}
-        onClickSave={moveDirectoryOrFileModal.value?.isDirectory ? onClickSaveMoveDirectory : onClickSaveMoveFile}
-        onClose={onClickCloseMove}
-      />
+      {!fileShareId
+        ? (
+          <MoveDirectoryOrFileModal
+            isOpen={moveDirectoryOrFileModal.value?.isOpen || false}
+            isDirectory={moveDirectoryOrFileModal.value?.isDirectory || false}
+            initialPath={moveDirectoryOrFileModal.value?.path || ''}
+            name={moveDirectoryOrFileModal.value?.name || ''}
+            onClickSave={moveDirectoryOrFileModal.value?.isDirectory ? onClickSaveMoveDirectory : onClickSaveMoveFile}
+            onClose={onClickCloseMove}
+          />
+        )
+        : null}
+
+      {!fileShareId
+        ? (
+          <CreateShareModal
+            isOpen={createShareModal.value?.isOpen || false}
+            filePath={createShareModal.value?.filePath || ''}
+            password={createShareModal.value?.password || ''}
+            onClickSave={onClickSaveFileShare}
+            onClose={onClickCloseFileShare}
+          />
+        )
+        : null}
+
+      {!fileShareId
+        ? (
+          <ManageShareModal
+            baseUrl={baseUrl}
+            isOpen={manageShareModal.value?.isOpen || false}
+            fileShareId={manageShareModal.value?.fileShareId || ''}
+            onClickSave={onClickUpdateFileShare}
+            onClickDelete={onClickDeleteFileShare}
+            onClose={onClickCloseManageShare}
+          />
+        )
+        : null}
     </>
   );
 }

--- a/components/files/ManageShareModal.tsx
+++ b/components/files/ManageShareModal.tsx
@@ -1,0 +1,121 @@
+import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+
+import { RequestBody, ResponseBody } from '/routes/api/files/get-share.tsx';
+import { FileShare } from '/lib/types.ts';
+
+interface ManageShareModalProps {
+  baseUrl: string;
+  isOpen: boolean;
+  fileShareId: string;
+  onClickSave: (fileShareId: string, password?: string) => Promise<void>;
+  onClickDelete: (fileShareId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function ManageShareModal(
+  { baseUrl, isOpen, fileShareId, onClickSave, onClickDelete, onClose }: ManageShareModalProps,
+) {
+  const newPassword = useSignal<string>('');
+
+  const isLoading = useSignal<boolean>(false);
+  const fileShare = useSignal<FileShare | null>(null);
+
+  useEffect(() => {
+    fetchFileShare();
+  }, [fileShareId]);
+
+  async function fetchFileShare() {
+    if (!fileShareId || isLoading.value) {
+      return;
+    }
+
+    isLoading.value = true;
+
+    try {
+      const requestBody: RequestBody = {
+        fileShareId,
+      };
+      const response = await fetch(`/api/files/get-share`, {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+      const result = await response.json() as ResponseBody;
+
+      if (!result.success) {
+        throw new Error('Failed to get file share!');
+      }
+
+      fileShare.value = result.fileShare;
+
+      isLoading.value = false;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return (
+    <>
+      <section
+        class={`fixed ${isOpen ? 'block' : 'hidden'} z-40 w-screen h-screen inset-0 bg-gray-900 bg-opacity-60`}
+      >
+      </section>
+
+      <section
+        class={`fixed ${
+          isOpen ? 'block' : 'hidden'
+        } z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 bg-slate-600 text-white rounded-md px-8 py-6 drop-shadow-lg overflow-y-scroll max-h-[80%]`}
+      >
+        <h1 class='text-2xl font-semibold my-5'>Manage Public Share Link</h1>
+        <section class='py-5 my-2 border-y border-slate-500'>
+          <section class='block mb-2'>
+            <span class='font-semibold my-2 block'>Public Share URL:</span>{' '}
+            <code class='bg-slate-700 my-2 px-2 py-1 rounded-md'>{baseUrl}/file-share/{fileShareId}</code>
+          </section>
+          <fieldset class='block mb-2'>
+            <label class='text-slate-300 block pb-1' for='password'>
+              {fileShare.value?.extra.hashed_password ? 'New Password' : 'Set Password'}
+            </label>
+            <input
+              class='input-field'
+              type='password'
+              name='password'
+              id='password'
+              value={newPassword.value}
+              onInput={(event) => {
+                newPassword.value = event.currentTarget.value;
+              }}
+              autocomplete='off'
+            />
+          </fieldset>
+        </section>
+        <footer class='flex justify-between'>
+          <button
+            class='px-5 py-2 bg-slate-600 hover:bg-slate-500 text-white cursor-pointer rounded-md'
+            onClick={() => {
+              onClickSave(fileShareId, newPassword.peek());
+              newPassword.value = '';
+            }}
+            type='button'
+          >
+            Update
+          </button>
+          <button
+            class='px-5 py-2 bg-red-600 hover:bg-red-500 text-white cursor-pointer rounded-md'
+            onClick={() => onClickDelete(fileShareId)}
+            type='button'
+          >
+            Delete
+          </button>
+          <button
+            class='px-5 py-2 bg-slate-600 hover:bg-slate-500 text-white cursor-pointer rounded-md'
+            onClick={() => onClose()}
+            type='button'
+          >
+            Close
+          </button>
+        </footer>
+      </section>
+    </>
+  );
+}

--- a/components/files/SearchFiles.tsx
+++ b/components/files/SearchFiles.tsx
@@ -116,7 +116,9 @@ export default function SearchFiles({}: SearchFilesProps) {
                   {matchingDirectories.value.map((directory) => (
                     <li class='mb-1'>
                       <a
-                        href={`/files?path=${directory.parent_path}${directory.directory_name}`}
+                        href={`/files?path=${encodeURIComponent(directory.parent_path)}${
+                          encodeURIComponent(directory.directory_name)
+                        }`}
                         class={`block px-2 py-2 hover:no-underline hover:opacity-60 bg-slate-700 cursor-pointer font-normal`}
                         target='_blank'
                         rel='noopener noreferrer'
@@ -136,7 +138,9 @@ export default function SearchFiles({}: SearchFilesProps) {
                   {matchingFiles.value.map((file) => (
                     <li class='mb-1'>
                       <a
-                        href={`/files/open/${file.file_name}?path=${file.parent_path}`}
+                        href={`/files/open/${encodeURIComponent(file.file_name)}?path=${
+                          encodeURIComponent(file.parent_path)
+                        }`}
                         class={`block px-2 py-2 hover:no-underline hover:opacity-60 bg-slate-700 cursor-pointer font-normal`}
                         target='_blank'
                         rel='noopener noreferrer'

--- a/components/files/ShareVerifyForm.tsx
+++ b/components/files/ShareVerifyForm.tsx
@@ -1,0 +1,58 @@
+interface ShareVerifyFormProps {
+  error?: { title: string; message: string };
+}
+
+export default function ShareVerifyForm(
+  { error }: ShareVerifyFormProps,
+) {
+  return (
+    <section class='max-w-md w-full mb-12'>
+      <section class='mb-6'>
+        <h2 class='mt-6 text-center text-3xl font-extrabold text-white'>
+          File Share Authentication
+        </h2>
+        <p class='mt-2 text-center text-sm text-gray-300'>
+          You are required to authenticate with a password
+        </p>
+      </section>
+
+      {error
+        ? (
+          <section class='notification-error'>
+            <h3>{error.title}</h3>
+            <p>{error.message}</p>
+          </section>
+        )
+        : null}
+
+      <form
+        class='mb-6'
+        method='POST'
+      >
+        <fieldset class='block mb-4'>
+          <label class='text-slate-300 block pb-1' for='token'>
+            Password
+          </label>
+          <input
+            type='password'
+            id='password'
+            name='password'
+            placeholder='Password'
+            class='mt-1 input-field'
+            autocomplete='off'
+            required
+          />
+        </fieldset>
+
+        <section class='flex justify-center mt-8 mb-4'>
+          <button
+            type='submit'
+            class='button'
+          >
+            Verify Password
+          </button>
+        </section>
+      </form>
+    </section>
+  );
+}

--- a/components/photos/ListPhotos.tsx
+++ b/components/photos/ListPhotos.tsx
@@ -30,7 +30,9 @@ export default function ListPhotos(
               return (
                 <article class='hover:opacity-70'>
                   <a
-                    href={`/files/open/${file.file_name}?path=${file.parent_path}`}
+                    href={`/files/open/${encodeURIComponent(file.file_name)}?path=${
+                      encodeURIComponent(file.parent_path)
+                    }`}
                     class='flex items-center'
                     target='_blank'
                     rel='noopener noreferrer'
@@ -39,7 +41,9 @@ export default function ListPhotos(
                       ? (
                         <video class='h-auto max-w-full rounded-md' title={file.file_name}>
                           <source
-                            src={`/files/open/${file.file_name}?path=${file.parent_path}`}
+                            src={`/files/open/${encodeURIComponent(file.file_name)}?path=${
+                              encodeURIComponent(file.parent_path)
+                            }`}
                             type={`video/${extensionName}`}
                           />
                         </video>
@@ -48,7 +52,9 @@ export default function ListPhotos(
                     {isImage
                       ? (
                         <img
-                          src={`/photos/thumbnail/${file.file_name}?path=${file.parent_path}`}
+                          src={`/photos/thumbnail/${encodeURIComponent(file.file_name)}?path=${
+                            encodeURIComponent(file.parent_path)
+                          }`}
                           class='h-auto max-w-full rounded-md'
                           alt={file.file_name}
                           title={file.file_name}

--- a/db-migrations/004-public-file-sharing.pgsql
+++ b/db-migrations/004-public-file-sharing.pgsql
@@ -1,0 +1,22 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+CREATE TABLE public.bewcloud_file_shares (
+    id uuid DEFAULT gen_random_uuid(),
+    user_id uuid DEFAULT gen_random_uuid(),
+    file_path text NOT NULL,
+    extra jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+ALTER TABLE ONLY public.bewcloud_file_shares ADD CONSTRAINT bewcloud_file_shares_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.bewcloud_file_shares ADD CONSTRAINT bewcloud_file_shares_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.bewcloud_users(id);
+ALTER TABLE ONLY public.bewcloud_file_shares ADD CONSTRAINT bewcloud_file_shares_user_id_file_path_unique UNIQUE (user_id, file_path);

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,14 @@
     "update": "deno run -A -r https://fresh.deno.dev/update .",
     "test": "deno test -A --check"
   },
-  "fmt": { "useTabs": false, "lineWidth": 120, "indentWidth": 2, "singleQuote": true, "proseWrap": "preserve" },
+  "fmt": {
+    "useTabs": false,
+    "lineWidth": 120,
+    "indentWidth": 2,
+    "singleQuote": true,
+    "proseWrap": "preserve",
+    "exclude": ["README.md"]
+  },
   "lint": {
     "rules": {
       "tags": ["fresh", "recommended"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   website:
-    image: ghcr.io/bewcloud/bewcloud:v2.1.0
+    image: ghcr.io/bewcloud/bewcloud:v2.2.0
     restart: always
     ports:
       - 127.0.0.1:8000:8000
@@ -10,7 +10,7 @@ services:
         required: true
     volumes:
       - ./data-files:/app/data-files
-      # - ./bewcloud.config.ts:/app/bewcloud.config.ts # uncomment if you need to override the default config
+      - ./bewcloud.config.ts:/app/bewcloud.config.ts
 
   postgresql:
     image: postgres:17

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -25,15 +25,19 @@ import * as $api_expenses_import_expenses from './routes/api/expenses/import-exp
 import * as $api_expenses_update_budget from './routes/api/expenses/update-budget.tsx';
 import * as $api_expenses_update_expense from './routes/api/expenses/update-expense.tsx';
 import * as $api_files_create_directory from './routes/api/files/create-directory.tsx';
+import * as $api_files_create_share from './routes/api/files/create-share.tsx';
 import * as $api_files_delete_directory from './routes/api/files/delete-directory.tsx';
+import * as $api_files_delete_share from './routes/api/files/delete-share.tsx';
 import * as $api_files_delete from './routes/api/files/delete.tsx';
 import * as $api_files_get_directories from './routes/api/files/get-directories.tsx';
+import * as $api_files_get_share from './routes/api/files/get-share.tsx';
 import * as $api_files_get from './routes/api/files/get.tsx';
 import * as $api_files_move_directory from './routes/api/files/move-directory.tsx';
 import * as $api_files_move from './routes/api/files/move.tsx';
 import * as $api_files_rename_directory from './routes/api/files/rename-directory.tsx';
 import * as $api_files_rename from './routes/api/files/rename.tsx';
 import * as $api_files_search from './routes/api/files/search.tsx';
+import * as $api_files_update_share from './routes/api/files/update-share.tsx';
 import * as $api_files_upload from './routes/api/files/upload.tsx';
 import * as $api_news_add_feed from './routes/api/news/add-feed.tsx';
 import * as $api_news_delete_feed from './routes/api/news/delete-feed.tsx';
@@ -44,6 +48,9 @@ import * as $api_notes_save from './routes/api/notes/save.tsx';
 import * as $dashboard from './routes/dashboard.tsx';
 import * as $dav from './routes/dav.tsx';
 import * as $expenses from './routes/expenses.tsx';
+import * as $file_share_fileShareId_ from './routes/file-share/[fileShareId].tsx';
+import * as $file_share_fileShareId_open_fileName_ from './routes/file-share/[fileShareId]/open/[fileName].tsx';
+import * as $file_share_fileShareId_verify from './routes/file-share/[fileShareId]/verify.tsx';
 import * as $files from './routes/files.tsx';
 import * as $files_open_fileName_ from './routes/files/open/[fileName].tsx';
 import * as $index from './routes/index.tsx';
@@ -98,15 +105,19 @@ const manifest = {
     './routes/api/expenses/update-budget.tsx': $api_expenses_update_budget,
     './routes/api/expenses/update-expense.tsx': $api_expenses_update_expense,
     './routes/api/files/create-directory.tsx': $api_files_create_directory,
+    './routes/api/files/create-share.tsx': $api_files_create_share,
     './routes/api/files/delete-directory.tsx': $api_files_delete_directory,
+    './routes/api/files/delete-share.tsx': $api_files_delete_share,
     './routes/api/files/delete.tsx': $api_files_delete,
     './routes/api/files/get-directories.tsx': $api_files_get_directories,
+    './routes/api/files/get-share.tsx': $api_files_get_share,
     './routes/api/files/get.tsx': $api_files_get,
     './routes/api/files/move-directory.tsx': $api_files_move_directory,
     './routes/api/files/move.tsx': $api_files_move,
     './routes/api/files/rename-directory.tsx': $api_files_rename_directory,
     './routes/api/files/rename.tsx': $api_files_rename,
     './routes/api/files/search.tsx': $api_files_search,
+    './routes/api/files/update-share.tsx': $api_files_update_share,
     './routes/api/files/upload.tsx': $api_files_upload,
     './routes/api/news/add-feed.tsx': $api_news_add_feed,
     './routes/api/news/delete-feed.tsx': $api_news_delete_feed,
@@ -117,6 +128,9 @@ const manifest = {
     './routes/dashboard.tsx': $dashboard,
     './routes/dav.tsx': $dav,
     './routes/expenses.tsx': $expenses,
+    './routes/file-share/[fileShareId].tsx': $file_share_fileShareId_,
+    './routes/file-share/[fileShareId]/open/[fileName].tsx': $file_share_fileShareId_open_fileName_,
+    './routes/file-share/[fileShareId]/verify.tsx': $file_share_fileShareId_verify,
     './routes/files.tsx': $files,
     './routes/files/open/[fileName].tsx': $files_open_fileName_,
     './routes/index.tsx': $index,

--- a/islands/files/FilesWrapper.tsx
+++ b/islands/files/FilesWrapper.tsx
@@ -6,11 +6,12 @@ interface FilesWrapperProps {
   initialFiles: DirectoryFile[];
   initialPath: string;
   baseUrl: string;
+  fileShareId?: string;
 }
 
 // This wrapper is necessary because islands need to be the first frontend component, but they don't support functions as props, so the more complex logic needs to live in the component itself
 export default function FilesWrapper(
-  { initialDirectories, initialFiles, initialPath, baseUrl }: FilesWrapperProps,
+  { initialDirectories, initialFiles, initialPath, baseUrl, fileShareId }: FilesWrapperProps,
 ) {
   return (
     <MainFiles
@@ -18,6 +19,7 @@ export default function FilesWrapper(
       initialFiles={initialFiles}
       initialPath={initialPath}
       baseUrl={baseUrl}
+      fileShareId={fileShareId}
     />
   );
 }

--- a/islands/files/FilesWrapper.tsx
+++ b/islands/files/FilesWrapper.tsx
@@ -6,12 +6,13 @@ interface FilesWrapperProps {
   initialFiles: DirectoryFile[];
   initialPath: string;
   baseUrl: string;
+  isFileSharingAllowed: boolean;
   fileShareId?: string;
 }
 
 // This wrapper is necessary because islands need to be the first frontend component, but they don't support functions as props, so the more complex logic needs to live in the component itself
 export default function FilesWrapper(
-  { initialDirectories, initialFiles, initialPath, baseUrl, fileShareId }: FilesWrapperProps,
+  { initialDirectories, initialFiles, initialPath, baseUrl, isFileSharingAllowed, fileShareId }: FilesWrapperProps,
 ) {
   return (
     <MainFiles
@@ -19,6 +20,7 @@ export default function FilesWrapper(
       initialFiles={initialFiles}
       initialPath={initialPath}
       baseUrl={baseUrl}
+      isFileSharingAllowed={isFileSharingAllowed}
       fileShareId={fileShareId}
     />
   );

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -21,6 +21,7 @@ export class AppConfig {
       },
       files: {
         rootPath: 'data-files',
+        allowPublicSharing: false,
       },
       core: {
         enabledApps: ['news', 'notes', 'photos', 'expenses'],
@@ -154,6 +155,12 @@ export class AppConfig {
     await this.loadConfig();
 
     return this.config.auth.enableSingleSignOn;
+  }
+
+  static async isPublicFileSharingAllowed(): Promise<boolean> {
+    await this.loadConfig();
+
+    return this.config.files.allowPublicSharing;
   }
 
   static async getFilesRootPath(): Promise<string> {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -93,6 +93,7 @@ export interface Directory {
   directory_name: string;
   has_write_access: boolean;
   size_in_bytes: number;
+  file_share_id: string | null;
   updated_at: Date;
   created_at: Date;
 }
@@ -103,6 +104,7 @@ export interface DirectoryFile {
   file_name: string;
   has_write_access: boolean;
   size_in_bytes: number;
+  file_share_id: string | null;
   updated_at: Date;
   created_at: Date;
 }
@@ -175,6 +177,8 @@ export interface Config {
   files: {
     /** The root-relative root path for files, i.e. "data-files" */
     rootPath: string;
+    /** If true, public file sharing will be allowed (still requires a user to enable sharing for a given file or directory) */
+    allowPublicSharing: boolean;
   };
   core: {
     /** dashboard and files cannot be disabled */
@@ -220,4 +224,14 @@ export interface MultiFactorAuthMethod {
       transports?: AuthenticatorTransport[];
     };
   };
+}
+
+export interface FileShare {
+  id: string;
+  user_id: string;
+  file_path: string;
+  extra: {
+    hashed_password?: string;
+  };
+  created_at: Date;
 }

--- a/routes/api/files/create-share.tsx
+++ b/routes/api/files/create-share.tsx
@@ -4,6 +4,7 @@ import { Directory, DirectoryFile, FileShare, FreshContextState } from '/lib/typ
 import { DirectoryModel, FileModel, FileShareModel, getPathInfo } from '/lib/models/files.ts';
 import { generateHash } from '/lib/utils/misc.ts';
 import { PASSWORD_SALT } from '/lib/auth.ts';
+import { AppConfig } from '/lib/config.ts';
 
 interface Data {}
 
@@ -24,6 +25,12 @@ export const handler: Handlers<Data, FreshContextState> = {
   async POST(request, context) {
     if (!context.state.user) {
       return new Response('Unauthorized', { status: 401 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Forbidden', { status: 403 });
     }
 
     const requestBody = await request.clone().json() as RequestBody;

--- a/routes/api/files/create-share.tsx
+++ b/routes/api/files/create-share.tsx
@@ -1,0 +1,79 @@
+import { Handlers } from 'fresh/server.ts';
+
+import { Directory, DirectoryFile, FileShare, FreshContextState } from '/lib/types.ts';
+import { DirectoryModel, FileModel, FileShareModel, getPathInfo } from '/lib/models/files.ts';
+import { generateHash } from '/lib/utils/misc.ts';
+import { PASSWORD_SALT } from '/lib/auth.ts';
+
+interface Data {}
+
+export interface RequestBody {
+  pathInView: string;
+  filePath: string;
+  password?: string;
+}
+
+export interface ResponseBody {
+  success: boolean;
+  newFiles: DirectoryFile[];
+  newDirectories: Directory[];
+  createdFileShareId: string;
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async POST(request, context) {
+    if (!context.state.user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const requestBody = await request.clone().json() as RequestBody;
+
+    if (
+      !requestBody.filePath || !requestBody.pathInView || !requestBody.filePath.trim() ||
+      !requestBody.pathInView.trim() || !requestBody.filePath.startsWith('/') ||
+      requestBody.filePath.includes('../') || !requestBody.pathInView.startsWith('/') ||
+      requestBody.pathInView.includes('../')
+    ) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    // Confirm the file path belongs to the user
+    const { isDirectory, isFile } = await getPathInfo(
+      context.state.user.id,
+      requestBody.filePath,
+    );
+
+    // Confirm the file path ends with a / if it's a directory, and doesn't end with a / if it's a file
+    if (isDirectory && !requestBody.filePath.endsWith('/')) {
+      requestBody.filePath = `${requestBody.filePath}/`;
+    } else if (isFile && requestBody.filePath.endsWith('/')) {
+      requestBody.filePath = requestBody.filePath.slice(0, -1);
+    }
+
+    const extra: FileShare['extra'] = {};
+
+    if (requestBody.password) {
+      extra.hashed_password = await generateHash(`${requestBody.password}:${PASSWORD_SALT}`, 'SHA-256');
+    }
+
+    const fileShare: Omit<FileShare, 'id' | 'created_at'> = {
+      user_id: context.state.user.id,
+      file_path: requestBody.filePath,
+      extra,
+    };
+
+    const createdFileShare = await FileShareModel.create(fileShare);
+
+    const newFiles = await FileModel.list(context.state.user.id, requestBody.pathInView);
+    const newDirectories = await DirectoryModel.list(context.state.user.id, requestBody.pathInView);
+
+    const responseBody: ResponseBody = {
+      success: true,
+      newFiles,
+      newDirectories,
+      createdFileShareId: createdFileShare.id,
+    };
+
+    return new Response(JSON.stringify(responseBody));
+  },
+};

--- a/routes/api/files/delete-share.tsx
+++ b/routes/api/files/delete-share.tsx
@@ -1,0 +1,49 @@
+import { Handlers } from 'fresh/server.ts';
+
+import { Directory, DirectoryFile, FreshContextState } from '/lib/types.ts';
+import { DirectoryModel, FileModel, FileShareModel } from '/lib/models/files.ts';
+
+interface Data {}
+
+export interface RequestBody {
+  pathInView: string;
+  fileShareId: string;
+}
+
+export interface ResponseBody {
+  success: boolean;
+  newFiles: DirectoryFile[];
+  newDirectories: Directory[];
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async POST(request, context) {
+    if (!context.state.user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const requestBody = await request.clone().json() as RequestBody;
+
+    if (
+      !requestBody.fileShareId || !requestBody.pathInView || !requestBody.pathInView.trim() ||
+      !requestBody.pathInView.startsWith('/') || requestBody.pathInView.includes('../')
+    ) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    const fileShare = await FileShareModel.getById(requestBody.fileShareId);
+
+    if (!fileShare || fileShare.user_id !== context.state.user.id) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    await FileShareModel.delete(requestBody.fileShareId);
+
+    const newFiles = await FileModel.list(context.state.user.id, requestBody.pathInView);
+    const newDirectories = await DirectoryModel.list(context.state.user.id, requestBody.pathInView);
+
+    const responseBody: ResponseBody = { success: true, newFiles, newDirectories };
+
+    return new Response(JSON.stringify(responseBody));
+  },
+};

--- a/routes/api/files/delete-share.tsx
+++ b/routes/api/files/delete-share.tsx
@@ -2,6 +2,7 @@ import { Handlers } from 'fresh/server.ts';
 
 import { Directory, DirectoryFile, FreshContextState } from '/lib/types.ts';
 import { DirectoryModel, FileModel, FileShareModel } from '/lib/models/files.ts';
+import { AppConfig } from '/lib/config.ts';
 
 interface Data {}
 
@@ -20,6 +21,12 @@ export const handler: Handlers<Data, FreshContextState> = {
   async POST(request, context) {
     if (!context.state.user) {
       return new Response('Unauthorized', { status: 401 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Forbidden', { status: 403 });
     }
 
     const requestBody = await request.clone().json() as RequestBody;

--- a/routes/api/files/get-share.tsx
+++ b/routes/api/files/get-share.tsx
@@ -2,6 +2,7 @@ import { Handlers } from 'fresh/server.ts';
 
 import { FileShare, FreshContextState } from '/lib/types.ts';
 import { FileShareModel } from '/lib/models/files.ts';
+import { AppConfig } from '/lib/config.ts';
 
 interface Data {}
 
@@ -18,6 +19,12 @@ export const handler: Handlers<Data, FreshContextState> = {
   async POST(request, context) {
     if (!context.state.user) {
       return new Response('Unauthorized', { status: 401 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Forbidden', { status: 403 });
     }
 
     const requestBody = await request.clone().json() as RequestBody;

--- a/routes/api/files/get-share.tsx
+++ b/routes/api/files/get-share.tsx
@@ -1,0 +1,39 @@
+import { Handlers } from 'fresh/server.ts';
+
+import { FileShare, FreshContextState } from '/lib/types.ts';
+import { FileShareModel } from '/lib/models/files.ts';
+
+interface Data {}
+
+export interface RequestBody {
+  fileShareId: string;
+}
+
+export interface ResponseBody {
+  success: boolean;
+  fileShare: FileShare;
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async POST(request, context) {
+    if (!context.state.user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const requestBody = await request.clone().json() as RequestBody;
+
+    if (!requestBody.fileShareId) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    const fileShare = await FileShareModel.getById(requestBody.fileShareId);
+
+    if (!fileShare || fileShare.user_id !== context.state.user.id) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const responseBody: ResponseBody = { success: true, fileShare };
+
+    return new Response(JSON.stringify(responseBody));
+  },
+};

--- a/routes/api/files/update-share.tsx
+++ b/routes/api/files/update-share.tsx
@@ -4,6 +4,7 @@ import { Directory, DirectoryFile, FreshContextState } from '/lib/types.ts';
 import { DirectoryModel, FileModel, FileShareModel } from '/lib/models/files.ts';
 import { generateHash } from '/lib/utils/misc.ts';
 import { PASSWORD_SALT } from '/lib/auth.ts';
+import { AppConfig } from '/lib/config.ts';
 
 interface Data {}
 
@@ -23,6 +24,12 @@ export const handler: Handlers<Data, FreshContextState> = {
   async POST(request, context) {
     if (!context.state.user) {
       return new Response('Unauthorized', { status: 401 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Forbidden', { status: 403 });
     }
 
     const requestBody = await request.clone().json() as RequestBody;

--- a/routes/api/files/update-share.tsx
+++ b/routes/api/files/update-share.tsx
@@ -1,0 +1,58 @@
+import { Handlers } from 'fresh/server.ts';
+
+import { Directory, DirectoryFile, FreshContextState } from '/lib/types.ts';
+import { DirectoryModel, FileModel, FileShareModel } from '/lib/models/files.ts';
+import { generateHash } from '/lib/utils/misc.ts';
+import { PASSWORD_SALT } from '/lib/auth.ts';
+
+interface Data {}
+
+export interface RequestBody {
+  pathInView: string;
+  fileShareId: string;
+  password?: string;
+}
+
+export interface ResponseBody {
+  success: boolean;
+  newFiles: DirectoryFile[];
+  newDirectories: Directory[];
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async POST(request, context) {
+    if (!context.state.user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const requestBody = await request.clone().json() as RequestBody;
+
+    if (
+      !requestBody.fileShareId || !requestBody.pathInView || !requestBody.pathInView.trim() ||
+      !requestBody.pathInView.startsWith('/') || requestBody.pathInView.includes('../')
+    ) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    const fileShare = await FileShareModel.getById(requestBody.fileShareId);
+
+    if (!fileShare || fileShare.user_id !== context.state.user.id) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (requestBody.password) {
+      fileShare.extra.hashed_password = await generateHash(`${requestBody.password}:${PASSWORD_SALT}`, 'SHA-256');
+    } else {
+      delete fileShare.extra.hashed_password;
+    }
+
+    await FileShareModel.update(fileShare);
+
+    const newFiles = await FileModel.list(context.state.user.id, requestBody.pathInView);
+    const newDirectories = await DirectoryModel.list(context.state.user.id, requestBody.pathInView);
+
+    const responseBody: ResponseBody = { success: true, newFiles, newDirectories };
+
+    return new Response(JSON.stringify(responseBody));
+  },
+};

--- a/routes/file-share/[fileShareId].tsx
+++ b/routes/file-share/[fileShareId].tsx
@@ -1,0 +1,132 @@
+import { Handlers, PageProps } from 'fresh/server.ts';
+import { join } from 'std/path/join.ts';
+
+import { Directory, DirectoryFile, FreshContextState } from '/lib/types.ts';
+import {
+  DirectoryModel,
+  ensureFileSharePathIsValidAndSecurelyAccessible,
+  FileModel,
+  FileShareModel,
+} from '/lib/models/files.ts';
+import { AppConfig } from '/lib/config.ts';
+import FilesWrapper from '/islands/files/FilesWrapper.tsx';
+
+interface Data {
+  shareDirectories: Directory[];
+  shareFiles: DirectoryFile[];
+  currentPath: string;
+  baseUrl: string;
+  fileShareId?: string;
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async GET(request, context) {
+    const { fileShareId } = context.params;
+
+    if (!fileShareId) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const baseUrl = (await AppConfig.getConfig()).auth.baseUrl;
+
+    const fileShare = await FileShareModel.getById(fileShareId);
+
+    if (!fileShare) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const searchParams = new URL(request.url).searchParams;
+
+    let currentPath = searchParams.get('path') || '/';
+
+    // Send invalid paths back to root
+    if (!currentPath.startsWith('/') || currentPath.includes('../')) {
+      currentPath = '/';
+    }
+
+    // Always append a trailing slash
+    if (!currentPath.endsWith('/')) {
+      currentPath = `${currentPath}/`;
+    }
+
+    // Confirm that currentPath is not _outside_ the fileShare.file_path
+    await ensureFileSharePathIsValidAndSecurelyAccessible(fileShare.user_id, fileShare.file_path, currentPath);
+
+    const isFileSharePathDirectory = fileShare.file_path.endsWith('/');
+
+    currentPath = isFileSharePathDirectory ? join(fileShare.file_path, currentPath) : fileShare.file_path;
+
+    const isFilePathDirectory = currentPath.endsWith('/');
+
+    const fileSharePathDirectory = isFileSharePathDirectory
+      ? fileShare.file_path
+      : `${fileShare.file_path.split('/').slice(0, -1).join('/')}/`;
+
+    const filePathDirectory = isFilePathDirectory ? currentPath : `${currentPath.split('/').slice(0, -1).join('/')}/`;
+
+    // Does the file share require a password? If so, redirect to the verification page
+    if (fileShare.extra.hashed_password) {
+      const { fileShareId: fileShareIdFromSession, hashedPassword: hashedPasswordFromSession } =
+        (await FileShareModel.getDataFromRequest(request)) || {};
+
+      if (
+        !fileShareIdFromSession || fileShareIdFromSession !== fileShareId ||
+        hashedPasswordFromSession !== fileShare.extra.hashed_password
+      ) {
+        return new Response('Redirect', { status: 303, headers: { 'Location': `/file-share/${fileShareId}/verify` } });
+      }
+    }
+
+    let shareDirectories = await DirectoryModel.list(
+      fileShare.user_id,
+      isFilePathDirectory ? currentPath : filePathDirectory,
+    );
+
+    let shareFiles = await FileModel.list(fileShare.user_id, isFilePathDirectory ? currentPath : filePathDirectory);
+
+    if (!isFileSharePathDirectory) {
+      shareDirectories = shareDirectories.filter((directory) =>
+        directory.directory_name === currentPath.split('/').pop()
+      );
+      shareFiles = shareFiles.filter((file) => file.file_name === currentPath.split('/').pop());
+    }
+
+    // Remove the filePathDirectory from the directories' paths, and set has_write_access to false
+    shareDirectories = shareDirectories.map((directory) => ({
+      ...directory,
+      has_write_access: false,
+      parent_path: directory.parent_path.replace(fileSharePathDirectory, '/'),
+    }));
+
+    // Remove the filePathDirectory from the files' paths, and set has_write_access to false
+    shareFiles = shareFiles.map((file) => ({
+      ...file,
+      has_write_access: false,
+      parent_path: file.parent_path.replace(fileSharePathDirectory, '/'),
+    }));
+
+    const publicCurrentPath = currentPath.replace(fileShare.file_path, '/');
+
+    return await context.render({ shareDirectories, shareFiles, currentPath: publicCurrentPath, baseUrl, fileShareId });
+  },
+};
+
+export default function FilesPage({ data }: PageProps<Data, FreshContextState>) {
+  return (
+    <main>
+      <FilesWrapper
+        initialDirectories={data.shareDirectories}
+        initialFiles={data.shareFiles}
+        initialPath={data.currentPath}
+        baseUrl={data.baseUrl}
+        fileShareId={data.fileShareId}
+      />
+    </main>
+  );
+}

--- a/routes/file-share/[fileShareId].tsx
+++ b/routes/file-share/[fileShareId].tsx
@@ -125,6 +125,7 @@ export default function FilesPage({ data }: PageProps<Data, FreshContextState>) 
         initialFiles={data.shareFiles}
         initialPath={data.currentPath}
         baseUrl={data.baseUrl}
+        isFileSharingAllowed
         fileShareId={data.fileShareId}
       />
     </main>

--- a/routes/file-share/[fileShareId]/open/[fileName].tsx
+++ b/routes/file-share/[fileShareId]/open/[fileName].tsx
@@ -1,0 +1,82 @@
+import { Handlers } from 'fresh/server.ts';
+import { join } from 'std/path/join.ts';
+
+import { FreshContextState } from '/lib/types.ts';
+import { ensureFileSharePathIsValidAndSecurelyAccessible, FileModel, FileShareModel } from '/lib/models/files.ts';
+import { AppConfig } from '/lib/config.ts';
+
+interface Data {}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async GET(request, context) {
+    const { fileShareId, fileName } = context.params;
+
+    if (!fileShareId || !fileName) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const fileShare = await FileShareModel.getById(fileShareId);
+
+    if (!fileShare) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (fileShare.extra.hashed_password) {
+      const { fileShareId: fileShareIdFromSession, hashedPassword: hashedPasswordFromSession } =
+        (await FileShareModel.getDataFromRequest(request)) || {};
+
+      if (
+        !fileShareIdFromSession || fileShareIdFromSession !== fileShareId ||
+        hashedPasswordFromSession !== fileShare.extra.hashed_password
+      ) {
+        return new Response('Redirect', { status: 303, headers: { 'Location': `/file-share/${fileShareId}/verify` } });
+      }
+    }
+
+    const searchParams = new URL(request.url).searchParams;
+
+    let currentPath = searchParams.get('path') || '/';
+
+    // Send invalid paths back to root
+    if (!currentPath.startsWith('/') || currentPath.includes('../')) {
+      currentPath = '/';
+    }
+
+    // Always append a trailing slash
+    if (!currentPath.endsWith('/')) {
+      currentPath = `${currentPath}/`;
+    }
+
+    // Confirm that currentPath is not _outside_ the fileShare.file_path
+    await ensureFileSharePathIsValidAndSecurelyAccessible(fileShare.user_id, fileShare.file_path, currentPath);
+
+    const isFileSharePathDirectory = fileShare.file_path.endsWith('/');
+
+    const fileSharePathDirectory = isFileSharePathDirectory
+      ? fileShare.file_path
+      : `${fileShare.file_path.split('/').slice(0, -1).join('/')}/`;
+
+    currentPath = isFileSharePathDirectory ? join(fileShare.file_path, currentPath) : fileSharePathDirectory;
+
+    const fileResult = await FileModel.get(fileShare.user_id, currentPath, decodeURIComponent(fileName));
+
+    if (!fileResult.success) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return new Response(fileResult.contents!, {
+      status: 200,
+      headers: {
+        'cache-control': 'no-cache, no-store, must-revalidate',
+        'content-type': fileResult.contentType!,
+        'content-length': fileResult.byteSize!.toString(),
+      },
+    });
+  },
+};

--- a/routes/file-share/[fileShareId]/verify.tsx
+++ b/routes/file-share/[fileShareId]/verify.tsx
@@ -1,0 +1,107 @@
+import { Handlers, PageProps } from 'fresh/server.ts';
+
+import { FreshContextState } from '/lib/types.ts';
+import { getFormDataField } from '/lib/form-utils.tsx';
+import { AppConfig } from '/lib/config.ts';
+import { FileShareModel } from '/lib/models/files.ts';
+import { generateHash } from '/lib/utils/misc.ts';
+import { PASSWORD_SALT } from '/lib/auth.ts';
+import ShareVerifyForm from '/components/files/ShareVerifyForm.tsx';
+
+interface Data {
+  error?: {
+    title: string;
+    message: string;
+  };
+}
+
+export const handler: Handlers<Data, FreshContextState> = {
+  async GET(request, context) {
+    const { fileShareId } = context.params;
+
+    if (!fileShareId) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const fileShare = await FileShareModel.getById(fileShareId);
+
+    if (!fileShare) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (!fileShare.extra.hashed_password) {
+      return new Response('Redirect', { status: 303, headers: { 'Location': `/file-share/${fileShareId}` } });
+    }
+
+    return await context.render({});
+  },
+  async POST(request, context) {
+    const { fileShareId } = context.params;
+
+    if (!fileShareId) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    if (!isPublicFileSharingAllowed) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const fileShare = await FileShareModel.getById(fileShareId);
+
+    if (!fileShare) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (!fileShare.extra.hashed_password) {
+      return new Response('Redirect', { status: 303, headers: { 'Location': `/file-share/${fileShareId}` } });
+    }
+
+    try {
+      const formData = await request.formData();
+      const password = getFormDataField(formData, 'password');
+
+      if (!password) {
+        throw new Error('Password is required');
+      }
+
+      const hashedPassword = await generateHash(`${password}:${PASSWORD_SALT}`, 'SHA-256');
+
+      if (hashedPassword !== fileShare.extra.hashed_password) {
+        throw new Error('Invalid password');
+      }
+
+      const response = new Response('Redirect', { status: 303, headers: { 'Location': `/file-share/${fileShareId}` } });
+
+      return await FileShareModel.createSessionCookie(request, response, fileShareId, hashedPassword);
+    } catch (error) {
+      console.error('File share verification error:', error);
+
+      return await context.render({
+        error: {
+          title: 'Verification Failed',
+          message: (error as Error).message,
+        },
+      });
+    }
+  },
+};
+
+export default function ShareVerifyPage({ data }: PageProps<Data, FreshContextState>) {
+  return (
+    <main>
+      <section class='max-w-screen-md mx-auto flex flex-col items-center justify-center'>
+        <ShareVerifyForm
+          error={data.error}
+        />
+      </section>
+    </main>
+  );
+}

--- a/routes/files.tsx
+++ b/routes/files.tsx
@@ -10,6 +10,7 @@ interface Data {
   userFiles: DirectoryFile[];
   currentPath: string;
   baseUrl: string;
+  isFileSharingAllowed: boolean;
 }
 
 export const handler: Handlers<Data, FreshContextState> = {
@@ -38,7 +39,15 @@ export const handler: Handlers<Data, FreshContextState> = {
 
     const userFiles = await FileModel.list(context.state.user.id, currentPath);
 
-    return await context.render({ userDirectories, userFiles, currentPath, baseUrl });
+    const isPublicFileSharingAllowed = await AppConfig.isPublicFileSharingAllowed();
+
+    return await context.render({
+      userDirectories,
+      userFiles,
+      currentPath,
+      baseUrl,
+      isFileSharingAllowed: isPublicFileSharingAllowed,
+    });
   },
 };
 
@@ -50,6 +59,7 @@ export default function FilesPage({ data }: PageProps<Data, FreshContextState>) 
         initialFiles={data.userFiles}
         initialPath={data.currentPath}
         baseUrl={data.baseUrl}
+        isFileSharingAllowed={data.isFileSharingAllowed}
       />
     </main>
   );


### PR DESCRIPTION
This implements public file sharing (read-only) with and without passwords (#57).

It also fixes a problem with filenames including special characters like `#` not working properly (#71).

You can share a directory or a single file, by using the new share icon on the right of the directories/files, and click on it to manage an existing file share (setting a new password, or deleting the file share).

There is some other minor cleanup and other copy updates in the README.

Closes #57
Fixes #71

---

### What it looks like

Accessing a password-protected share:
<img width="584" alt="Screenshot 2025-06-20 at 12 00 07" src="https://github.com/user-attachments/assets/da84b44e-2e20-40a7-bb4c-290918ae675e" />

Accessing a shared directory:
<img width="1306" alt="Screenshot 2025-06-20 at 12 00 23" src="https://github.com/user-attachments/assets/a875cd7d-b699-4d22-8226-feebc5ae8c66" />

Accessing a directory inside a shared directory:
<img width="1253" alt="Screenshot 2025-06-20 at 12 00 32" src="https://github.com/user-attachments/assets/892c39c7-4360-44ce-b9a2-0d407e12e107" />

Accessing a shared file:
<img width="1278" alt="Screenshot 2025-06-20 at 12 00 50" src="https://github.com/user-attachments/assets/a6b5c6f7-3b48-4076-a4f4-a56f08983804" />

Managing/viewing a shared link:
<img width="430" alt="Screenshot 2025-06-20 at 12 01 01" src="https://github.com/user-attachments/assets/46b76c08-6466-4e4d-85ac-407312ac7f74" />
