### PR TITLE
Make file and directory sorting case-insensitive

### DIFF
--- a/lib/utils/files.ts
+++ b/lib/utils/files.ts
@@ -21,8 +21,8 @@ export function humanFileSize(bytes: number) {
 }
 
 export function sortEntriesByName(entryA: Deno.DirEntry, entryB: Deno.DirEntry) {
-  const nameA = entryA.name.toLowerCase();
-  const nameB = entryB.name.toLowerCase();
+  const nameA = entryA.name.toLocaleLowerCase();
+  const nameB = entryB.name.toLocaleLowerCase();
   
   if (nameA > nameB) {
     return 1;
@@ -36,8 +36,8 @@ export function sortEntriesByName(entryA: Deno.DirEntry, entryB: Deno.DirEntry) 
 }
 
 export function sortDirectoriesByName(directoryA: Directory, directoryB: Directory) {
-  const nameA = directoryA.directory_name.toLowerCase();
-  const nameB = directoryB.directory_name.toLowerCase();
+  const nameA = directoryA.directory_name.toLocaleLowerCase();
+  const nameB = directoryB.directory_name.toLocaleLowerCase();
   
   if (nameA > nameB) {
     return 1;
@@ -51,8 +51,8 @@ export function sortDirectoriesByName(directoryA: Directory, directoryB: Directo
 }
 
 export function sortFilesByName(fileA: DirectoryFile, fileB: DirectoryFile) {
-  const nameA = fileA.file_name.toLowerCase();
-  const nameB = fileB.file_name.toLowerCase();
+  const nameA = fileA.file_name.toLocaleLowerCase();
+  const nameB = fileB.file_name.toLocaleLowerCase();
   
   if (nameA > nameB) {
     return 1;


### PR DESCRIPTION
Updated sorting functions to compare names in lowercase, ensuring case-insensitive sorting for files and directories. Addresses #101.

<img width="2461" height="1027" alt="image" src="https://github.com/user-attachments/assets/c753fdeb-65f2-44e0-8b84-8635719ec679" />
