### PR TITLE
Add SQLite support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 PORT=8000
 
+# These POSTGRESQL_* below are only used if the config.core.databaseEngine is 'postgresql'
 POSTGRESQL_HOST="postgresql" # docker container name or external hostname/IP
 POSTGRESQL_USER="postgres"
 POSTGRESQL_PASSWORD="fake"

--- a/bewcloud.config.sample.ts
+++ b/bewcloud.config.sample.ts
@@ -22,6 +22,8 @@ const config: PartialDeep<Config> = {
   // },
   // core: {
   //   enabledApps: ['news', 'notes', 'photos', 'expenses', 'contacts', 'calendar'], // dashboard and files cannot be disabled
+  //   databaseEngine: 'postgresql', // The database engine to use. Currently only 'postgresql' and 'sqlite' are supported.
+  //   sqliteFilePath: '', // The path to the SQLite database file. Only used if databaseEngine is 'sqlite'.
   // },
   // visuals: {
   //   title: 'My own cloud',

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -26,6 +26,8 @@ export class AppConfig {
       },
       core: {
         enabledApps: ['news', 'notes', 'photos', 'expenses', 'contacts', 'calendar'],
+        databaseEngine: 'postgresql',
+        sqliteFilePath: '',
       },
       visuals: {
         title: '',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -190,6 +190,10 @@ export interface Config {
   core: {
     /** dashboard and files cannot be disabled */
     enabledApps: OptionalApp[];
+    /** The database engine to use. Currently only 'postgresql' and 'sqlite' are supported. */
+    databaseEngine: 'postgresql' | 'sqlite';
+    /** The path to the SQLite database file. Only used if databaseEngine is 'sqlite'. */
+    sqliteFilePath: string;
   };
   visuals: {
     /** An override title of the application. Empty shows the default title. */

--- a/migrate-db.ts
+++ b/migrate-db.ts
@@ -72,7 +72,7 @@ async function runMigrations(missingMigrations: string[]): Promise<void> {
 
       await db.query(migrationSql);
 
-      await db.query(sql`INSERT INTO "public"."bewcloud_migrations" ("name", "executed_at") VALUES ($1, NOW())`, [
+      await db.query(sql`INSERT INTO "bewcloud_migrations" ("name", "executed_at") VALUES ($1, NOW())`, [
         missingMigration,
       ]);
 


### PR DESCRIPTION
This adds SQLite support, but a few queries are broken because they're PostgreSQL-exclusive/specific.

I don't see enough value (at least for now) in making the queries harder to read (or the code around them) "just" to enable SQLite support, so I'll abandon this for now, but push the code up in case it helps anyone else add this kind of support (and then change the queries for themselves).

Related to #49