### PR TITLE
Expose all of nodemailer’s transport settings using a new transportConfig configuration subkey

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,5 +16,5 @@ MFA_SALT="fake" # optional, if you want to enable multi-factor authentication
 OIDC_CLIENT_ID="fake" # optional, if you want to enable SSO (Single Sign-On)
 OIDC_CLIENT_SECRET="fake" # optional, if you want to enable SSO (Single Sign-On)
 
-SMTP_USERNAME="fake" # optional, if you want to enable signup email verification or multi-factor authentication via email
-SMTP_PASSWORD="fake" # optional, if you want to enable signup email verification or multi-factor authentication via email
+SMTP_USERNAME="fake" # optional, if you want to use a mail service requiring password authentication
+SMTP_PASSWORD="fake" # optional, if you want to use a mail service requiring password authentication

--- a/bewcloud.config.sample.ts
+++ b/bewcloud.config.sample.ts
@@ -30,8 +30,10 @@ const config: PartialDeep<Config> = {
   // },
   // email: {
   //   from: 'help@bewcloud.com',
-  //   host: 'localhost',
-  //   port: 465,
+  //   transportConfig: {  // Specify any needed options listed at https://nodemailer.com/smtp here; authentication data will automatically be added if specify using the `SMTP_USERNAME` and `SMTP_PASSWORD` environment variables
+  //     host: 'localhost',
+  //     port: 465,
+  //   },
   // },
   // contacts: {
   //   enableCardDavServer: true,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -35,8 +35,10 @@ export class AppConfig {
       },
       email: {
         from: 'help@bewcloud.com',
-        host: 'localhost',
-        port: 465,
+        transportConfig: {
+          host: 'localhost',
+          port: 465,
+        },
       },
       contacts: {
         enableCardDavServer: true,
@@ -94,6 +96,16 @@ export class AppConfig {
           ...configFromFile.calendar,
         },
       };
+
+      // Support for older transport configuration settings
+      if (typeof(this.config.email.host) !== "undefined") {
+        console.warn('Config entry “email.host” has been renamed to “email.transportConfig.host”');
+        this.config.email.transportConfig.host = this.config.email.host;
+      }
+      if (typeof(this.config.email.port) !== "undefined") {
+        console.warn('Config entry “email.port” has been renamed to “email.transportConfig.port”');
+        this.config.email.transportConfig.port = this.config.email.port;
+      }
 
       console.info('\nConfig loaded from bewcloud.config.ts', JSON.stringify(this.config, null, 2), '\n');
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -202,10 +202,21 @@ export interface Config {
   email: {
     /** The email address to send emails from */
     from: string;
-    /** The SMTP host to send emails from */
+    /** Deprecated alias for .transportConfig.host */
     host: string;
-    /** The SMTP port to send emails from */
+    /** Deprecated alias for .transportConfig.host */
     port: number;
+    /** Transport options to pass to nodemailer (see https://nodemailer.com/smtp) */
+    transportConfig: {
+      /** The SMTP host to send emails from */
+      host: string;
+      /** The SMTP port to send emails from */
+      port: number;
+      /** Whether to use immediate TLS or not (defaults to `true` if port is 465, `false` otherwise) */
+      secure?: boolean;
+      /** Other transport properties */
+      [_: string]: string|number|boolean|object;
+    };
   };
   contacts: {
     /** If true, the CardDAV server will be enabled (proxied) */


### PR DESCRIPTION
All known documentation has been updated to expose host and port below this new key. Existing configuration continues to work but shows a warning on startup.

I’ve also published a (Docker-less) NixOS integration module for bewCloud at https://gitlab.com/ntninja/bewcloud-nixos/. (Currently still targeting NixOS 25.05, since I’m not able to upgrade as NixOS 25.11 dropped some software – including Seafile, which is what caused me to look for alternatives that don’t revel in being a maintainers nightmare to begin with.)