### PR TITLE
Add reference to `bewcloud-nixos` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ You can simply `ln -s /<absolute-path-to-data-files>/<owner-user-id>/<directory-
 
 ## Community Links
 
- * [`bewcloud-nixos`](https://gitlab.com/ntninja/bewcloud-nixos/) by @ntninja exposes bewCloud as a NixOS integration as an alternative to using Docker.
+ * [`bewcloud-nixos`](https://gitlab.com/ntninja/bewcloud-nixos/) by @ntninja exposes bewCloud as a NixOS integration as an alternative to using Docker or running the app locally.
     * For installation and known limitations, please see its [README](https://gitlab.com/ntninja/bewcloud-nixos/-/blob/main/README.md).


### PR DESCRIPTION
As requested in https://github.com/bewcloud/bewcloud/pull/125#issuecomment-3612270900.

Also referenced from installation section as an untested alternative.