### PR TITLE
docs: Update bewcloud-nixos link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ Just push to the `main` branch.
 
 These are not officially endorsed, but are alternative ways of running bewCloud.
 
-- [`bewcloud-nixos`](https://gitlab.com/ntninja/bewcloud-nixos/) by [@ntninja](https://github.com/ntninja) exposes bewCloud as a NixOS integration as an alternative to using Docker or running the app locally.
-  - For installation and known limitations, please see its [README](https://gitlab.com/ntninja/bewcloud-nixos/-/blob/main/README.md).
+- [`bewcloud-nixos`](https://codeberg.org/ntninja/bewcloud-nixos/) by [@ntninja](https://codeberg.org/ntninja/) exposes bewCloud as an easy-to-use NixOS integration as an alternative to using Docker or running the app locally.
+  - For installation, please see the [README](https://codeberg.org/ntninja/bewcloud-nixos/src/branch/main/README.md).


### PR DESCRIPTION
It’s now actually Docker-level easy to use (no more manual installation) and also hosted on Codeberg.

Solution before was not a lot better than completely manual (even if there were still a bunch of things going on behind the scenes), this is now actually user-friendly even if it commits the crime of having Deno download all bewCloud dependencies on startup as Deno is a truely cursed thing to work with if your setup involves read-only filesystems (which Nix uses for reproducibility). – You’re only not affected by this in Docker because it mounts you a throw-away read-write filesystem that Deno can mess around in for no good reason, but yeah, not something users have to worry about now.