### PR TITLE
Fix logout page reference

### DIFF
--- a/routes.ts
+++ b/routes.ts
@@ -332,7 +332,7 @@ const routes: Routes = {
   index: createPageRouteHandler('index.ts', '/'),
   login: createPageRouteHandler('login.tsx', '/login'),
   signup: createPageRouteHandler('signup.ts', '/signup'),
-  logout: createPageRouteHandler('login.ts', '/logout'),
+  logout: createPageRouteHandler('logout.ts', '/logout'),
   caldav: createPageRouteHandler('caldav.ts', '/caldav/:path*{/}?'),
   calendar: createPageRouteHandler('calendar.ts', '/calendar'),
   calendars: createPageRouteHandler('calendars.ts', '/calendars'),


### PR DESCRIPTION
In bewCloud 4.0.0, clicking “Logout” results in an error due to a typo in the `routes.ts` file.

Also kudos to this release, dropping Fresh made this significantly easier to package since it now stops trying to rewrite itself all the time (except for Deno bug https://github.com/denoland/deno/issues/31489 of course…)!