### PR TITLE
feat: update README.md to include myself with helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,6 @@ These are not officially endorsed, but are alternative ways of running bewCloud.
 
 - [`bewcloud-nixos`](https://codeberg.org/ntninja/bewcloud-nixos/) by [@ntninja](https://codeberg.org/ntninja/) exposes bewCloud as an easy-to-use NixOS integration as an alternative to using Docker or running the app locally.
   - For installation, please see the [README](https://codeberg.org/ntninja/bewcloud-nixos/src/branch/main/README.md).
+- [`bewcloud-helm`](https://github.com/loboda4450/charts/tree/main/charts/bewcloud) by [@loboda4450](https://github.com/loboda4450/) exposes bewCloud as a Helm chart.
+  - For installation, please see the [README](https://github.com/loboda4450/charts/blob/main/charts/bewcloud/README.md)
+  - Supports automatic migrations, Radicale installation (as a dependency chart) and streamlined, fully yaml-based configuration.


### PR DESCRIPTION
Why bother?
- No chart exists - Kubernetes users currently have to roll their own manifests
- Automatic database migrations - Runs as a pre-install/pre-upgrade Job, no more "oops I forgot to migrate"
- Pure YAML configuration - Configure everything in values.yaml instead of dealing with TypeScript and ini config files
- Supports existing secrets - Works with external secret managers (Vault, ESO, etc.) via existingSecret references, making it GitOps-friendly
- Optional Radicale integration - Bundled as a subchart for CalDAV/CardDAV if needed (also created by me btw)
- Built on bjw-s common library - Less template code to maintain, well-tested foundation