### PR TITLE
Enable SSO signups

### DIFF
--- a/bewcloud.config.sample.ts
+++ b/bewcloud.config.sample.ts
@@ -11,7 +11,7 @@ const config: PartialDeep<Config> = {
     // allowedCookieDomains: ['example.com', 'example.net'], // Can be set to allow more than the baseUrl's domain for session cookies
     // skipCookieDomainSecurity: true, // If true, the cookie domain will not be strictly set and checked against. This skipping slightly reduces security, but is usually necessary for reverse proxies like Cloudflare Tunnel
     // enableSingleSignOn: false, // If true, single sign-on will be enabled
-    // allowSingleSignOnSignups: false, // If true, single sign-on signups will be allowed overriding allowSignups
+    // allowSignupsViaSingleSignOn: false, // If true, signups via single sign-on will be allowed, overriding allowSignups
     // singleSignOnUrl: '', // The Discovery URL (AKA Issuer) of the identity/single sign-on provider
     // singleSignOnEmailAttribute: 'email', // The attribute to prefer as email of the identity/single sign-on provider
     // singleSignOnScopes: ['openid', 'email'], // The scopes to request from the identity/single sign-on provider

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,7 +16,7 @@ export class AppConfig {
         allowedCookieDomains: [],
         skipCookieDomainSecurity: false,
         enableSingleSignOn: false,
-        allowSingleSignOnSignups: false,
+        allowSignupsViaSingleSignOn: false,
         singleSignOnUrl: '',
         singleSignOnEmailAttribute: 'email',
         singleSignOnScopes: ['openid', 'email'],
@@ -118,10 +118,10 @@ export class AppConfig {
     return this.config;
   }
 
-  static async isSignupAllowed(sso: boolean = false): Promise<boolean> {
+  static async isSignupAllowed({ viaSingleSignOn = false }: { viaSingleSignOn?: boolean } = {}): Promise<boolean> {
     await this.loadConfig();
 
-    const areSignupsAllowed = sso ? this.config.auth.allowSingleSignOnSignups : this.config.auth.allowSignups;
+    const areSignupsAllowed = viaSingleSignOn && !this.config.auth.allowSignups ? this.config.auth.allowSingleSignOnSignups : this.config.auth.allowSignups;
     const areThereAdmins = await UserModel.isThereAnAdmin();
 
     return areSignupsAllowed || !areThereAdmins;

--- a/lib/models/oidc.ts
+++ b/lib/models/oidc.ts
@@ -169,7 +169,7 @@ export class OidcModel {
       throw new Error(`Missing user/${emailAttribute}`);
     }
 
-    const isSignupAllowed = await AppConfig.isSignupAllowed(true);
+    const isSignupAllowed = await AppConfig.isSignupAllowed({ viaSingleSignOn: true });
     const isThereAnAdmin = await UserModel.isThereAnAdmin();
 
     // Confirm the user exists (or signup if allowed)
@@ -181,9 +181,8 @@ export class OidcModel {
     }
 
     if (!user) {
-      // this will allow admin account creation even if SSO signups are disabled following the foregoing logic
-      if (!config.auth.allowSingleSignOnSignups) {
-        throw new Error('Sign up via SSO is not allowed');
+      if (!config.auth.allowSignupsViaSingleSignOn) {
+        throw new Error('Sign up via SSO is not allowed!');
       }
 
       throw new Error('There was a problem signing up or logging in!');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -159,8 +159,8 @@ export interface Config {
     skipCookieDomainSecurity: boolean;
     /** If true, single sign-on will be enabled */
     enableSingleSignOn: boolean;
-    /** If true, single sign-on signups will be allowed overriding allowSignups */
-    allowSingleSignOnSignups: boolean;
+    /** If true, signups via single sign-on will be allowed, overriding allowSignups */
+    allowSignupsViaSingleSignOn: boolean;
     /** The Discovery URL (AKA Issuer) of the identity/single sign-on provider */
     singleSignOnUrl: string;
     /** The attribute to prefer as email of the identity/single sign-on provider */


### PR DESCRIPTION
First, admin user created from SSO:
<img width="1373" height="48" alt="image_2026-02-25_17-40-56" src="https://github.com/user-attachments/assets/8602b575-47cf-449f-bc6b-92c22d8d1978" />

More verbose error banner while SSO signups are disabled:
<img width="887" height="506" alt="image" src="https://github.com/user-attachments/assets/94bce332-2d07-4407-82ee-60a5f1098672" />

If you want to test it on your own here is already build docker image you can use: https://github.com/users/loboda4450/packages/container/package/bewcloud

Closes #151

