### PR TITLE
Add chunked file upload to bypass proxy request size limits

### DIFF
--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -201,6 +201,8 @@ export default function MainFiles(
           fileParentPath = `${path.value}${directoryPath}`;
         }
 
+        uploadProgress.value = '';
+
         try {
           if (chosenFile.size >= CHUNK_SIZE_BYTES) {
             await uploadFileChunked(chosenFile, fileParentPath);

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -2,6 +2,7 @@ import { useSignal } from '@preact/signals';
 
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
+import { ResponseBody as ChunkUploadResponseBody } from '/pages/api/files/upload-chunk.ts';
 import { RequestBody as RenameRequestBody, ResponseBody as RenameResponseBody } from '/pages/api/files/rename.ts';
 import { RequestBody as MoveRequestBody, ResponseBody as MoveResponseBody } from '/pages/api/files/move.ts';
 import { RequestBody as DeleteRequestBody, ResponseBody as DeleteResponseBody } from '/pages/api/files/delete.ts';
@@ -65,6 +66,7 @@ export default function MainFiles(
 ) {
   const isAdding = useSignal<boolean>(false);
   const isUploading = useSignal<boolean>(false);
+  const uploadProgress = useSignal<string>('');
   const isDeleting = useSignal<boolean>(false);
   const isUpdating = useSignal<boolean>(false);
   const directories = useSignal<Directory[]>(initialDirectories);
@@ -86,6 +88,83 @@ export default function MainFiles(
   const createShareModal = useSignal<{ isOpen: boolean; filePath: string; password?: string } | null>(null);
   const manageShareModal = useSignal<{ isOpen: boolean; fileShareId: string } | null>(null);
 
+  // 10 MB chunks keep each request well under Cloudflare Tunnel's 100 MB limit.
+  const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+
+  async function uploadFileSingle(chosenFile: File, parentPath: string) {
+    const requestBody = new FormData();
+    requestBody.set('path_in_view', path.value);
+    requestBody.set('parent_path', parentPath);
+    requestBody.set('name', chosenFile.name);
+    requestBody.set('contents', chosenFile);
+
+    const response = await fetch(`/api/files/upload`, {
+      method: 'POST',
+      body: requestBody,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+    }
+
+    const result = await response.json() as UploadResponseBody;
+
+    if (!result.success) {
+      throw new Error('Failed to upload file!');
+    }
+
+    files.value = [...result.newFiles];
+    directories.value = [...result.newDirectories];
+  }
+
+  async function uploadFileChunked(chosenFile: File, parentPath: string) {
+    const totalChunks = Math.ceil(chosenFile.size / CHUNK_SIZE_BYTES);
+    const uploadId = crypto.randomUUID();
+    // Capture once — the user may navigate away during a long upload, which
+    // would change path.value and cause the final response to refresh the
+    // wrong directory listing.
+    const pathInView = path.value;
+
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+      uploadProgress.value = `Uploading ${chosenFile.name} (${chunkIndex + 1}/${totalChunks})…`;
+
+      const start = chunkIndex * CHUNK_SIZE_BYTES;
+      const end = Math.min(start + CHUNK_SIZE_BYTES, chosenFile.size);
+      const chunkBlob = chosenFile.slice(start, end);
+
+      const requestBody = new FormData();
+      requestBody.set('upload_id', uploadId);
+      requestBody.set('chunk_index', String(chunkIndex));
+      requestBody.set('total_chunks', String(totalChunks));
+      requestBody.set('path_in_view', pathInView);
+      requestBody.set('parent_path', parentPath);
+      requestBody.set('name', chosenFile.name);
+      requestBody.set('chunk', chunkBlob);
+
+      const response = await fetch(`/api/files/upload-chunk`, {
+        method: 'POST',
+        body: requestBody,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`,
+        );
+      }
+
+      const result = await response.json() as ChunkUploadResponseBody;
+
+      if (!result.success) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+      }
+
+      if (result.isComplete) {
+        files.value = [...result.newFiles!];
+        directories.value = [...result.newDirectories!];
+      }
+    }
+  }
+
   function onClickUploadFile(uploadDirectory = false) {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -105,6 +184,7 @@ export default function MainFiles(
       const chosenFiles = Array.from(chosenFilesList);
 
       isUploading.value = true;
+      uploadProgress.value = '';
 
       for (const chosenFile of chosenFiles) {
         if (!chosenFile) {
@@ -113,38 +193,20 @@ export default function MainFiles(
 
         areNewOptionsOpen.value = false;
 
-        const requestBody = new FormData();
-        requestBody.set('path_in_view', path.value);
-        requestBody.set('parent_path', path.value);
-        requestBody.set('name', chosenFile.name);
-        requestBody.set('contents', chosenFile);
-
-        // Keep directory structure if the file comes from a chosen directory
+        // Resolve the parent path, keeping any sub-directory structure from directory uploads
+        let fileParentPath = path.value;
         if (chosenFile.webkitRelativePath) {
           const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
-
           // We don't need to worry about path joining here, the API will handle it (and make sure it's secure)
-          requestBody.set('parent_path', `${path.value}${directoryPath}`);
+          fileParentPath = `${path.value}${directoryPath}`;
         }
 
         try {
-          const response = await fetch(`/api/files/upload`, {
-            method: 'POST',
-            body: requestBody,
-          });
-
-          if (!response.ok) {
-            throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+          if (chosenFile.size >= CHUNK_SIZE_BYTES) {
+            await uploadFileChunked(chosenFile, fileParentPath);
+          } else {
+            await uploadFileSingle(chosenFile, fileParentPath);
           }
-
-          const result = await response.json() as UploadResponseBody;
-
-          if (!result.success) {
-            throw new Error('Failed to upload file!');
-          }
-
-          files.value = [...result.newFiles];
-          directories.value = [...result.newDirectories];
         } catch (error) {
           console.error(error);
         }
@@ -880,7 +942,8 @@ export default function MainFiles(
           {isUploading.value
             ? (
               <>
-                <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />Uploading...
+                <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />
+                {uploadProgress.value || 'Uploading…'}
               </>
             )
             : null}

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -1,0 +1,165 @@
+import { join } from '@std/path';
+
+import page, { RequestHandlerParams } from '/lib/page.ts';
+import { Directory, DirectoryFile } from '/lib/types.ts';
+import { DirectoryModel, ensureUserPathIsValidAndSecurelyAccessible, FileModel } from '/lib/models/files.ts';
+import { AppConfig } from '/lib/config.ts';
+
+export interface ResponseBody {
+  success: boolean;
+  isComplete: boolean;
+  newFiles?: DirectoryFile[];
+  newDirectories?: Directory[];
+}
+
+// Deno.FsFile.write() may do short writes (like POSIX write()), so loop until
+// all bytes are written.
+async function writeAll(file: Deno.FsFile, data: Uint8Array): Promise<void> {
+  let offset = 0;
+  while (offset < data.length) {
+    offset += await file.write(data.subarray(offset));
+  }
+}
+
+// Remove upload dirs for this user that have not been touched in over 24 hours.
+async function cleanStaleUploads(userUploadDir: string): Promise<void> {
+  const maxAgeMs = 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  try {
+    for await (const entry of Deno.readDir(userUploadDir)) {
+      const entryPath = join(userUploadDir, entry.name);
+      try {
+        const stat = await Deno.stat(entryPath);
+        if (now - (stat.mtime?.getTime() ?? 0) > maxAgeMs) {
+          await Deno.remove(entryPath, { recursive: true });
+        }
+      } catch {
+        // ignore per-entry errors
+      }
+    }
+  } catch {
+    // ignore if the user upload dir doesn't exist yet
+  }
+}
+
+async function post({ request, user }: RequestHandlerParams) {
+  if (
+    !(await AppConfig.isAppEnabled('files')) && !(await AppConfig.isAppEnabled('photos')) &&
+    !(await AppConfig.isAppEnabled('notes'))
+  ) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const requestBody = await request.clone().formData();
+
+  const uploadId = requestBody.get('upload_id') as string;
+  const chunkIndexStr = requestBody.get('chunk_index') as string;
+  const totalChunksStr = requestBody.get('total_chunks') as string;
+  const pathInView = requestBody.get('path_in_view') as string;
+  const parentPath = requestBody.get('parent_path') as string;
+  const name = requestBody.get('name') as string;
+  const chunk = requestBody.get('chunk') as File | null;
+
+  const chunkIndex = parseInt(chunkIndexStr, 10);
+  const totalChunks = parseInt(totalChunksStr, 10);
+
+  if (
+    !uploadId ||
+    !/^[a-zA-Z0-9-]+$/.test(uploadId) ||
+    isNaN(chunkIndex) || chunkIndex < 0 ||
+    isNaN(totalChunks) || totalChunks < 1 ||
+    chunkIndex >= totalChunks ||
+    !parentPath ||
+    !pathInView ||
+    !name?.trim() ||
+    !chunk ||
+    !parentPath.startsWith('/') ||
+    parentPath.includes('../') ||
+    !pathInView.startsWith('/') ||
+    pathInView.includes('../')
+  ) {
+    return new Response('Bad Request', { status: 400 });
+  }
+
+  try {
+    await ensureUserPathIsValidAndSecurelyAccessible(user!.id, join(parentPath, name.trim()));
+  } catch {
+    return new Response('Bad Request', { status: 400 });
+  }
+
+  const filesRootPath = await AppConfig.getFilesRootPath();
+  const userUploadDir = join(filesRootPath, '.chunk-uploads', user!.id);
+  const uploadDir = join(userUploadDir, uploadId);
+
+  // On the first chunk of a new upload, evict any stale sessions from this user.
+  if (chunkIndex === 0) {
+    await cleanStaleUploads(userUploadDir);
+  }
+
+  try {
+    await Deno.mkdir(uploadDir, { recursive: true });
+
+    const chunkData = await chunk.arrayBuffer();
+    await Deno.writeFile(join(uploadDir, String(chunkIndex)), new Uint8Array(chunkData));
+
+    // Count how many chunk files are present so far
+    let receivedCount = 0;
+    for await (const _entry of Deno.readDir(uploadDir)) {
+      receivedCount++;
+    }
+
+    if (receivedCount < totalChunks) {
+      const responseBody: ResponseBody = { success: true, isComplete: false };
+      return new Response(JSON.stringify(responseBody));
+    }
+
+    // All chunks present — assemble the final file
+    const finalParentDir = join(filesRootPath, user!.id, parentPath);
+    await Deno.mkdir(finalParentDir, { recursive: true });
+
+    const finalFilePath = join(finalParentDir, name.trim());
+
+    // Open with createNew:true to match the single-upload behaviour (reject if file already exists)
+    let finalFile: Deno.FsFile;
+
+    try {
+      finalFile = await Deno.open(finalFilePath, { write: true, createNew: true });
+    } catch (error) {
+      await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
+      console.error(error);
+      const responseBody: ResponseBody = { success: false, isComplete: true };
+      return new Response(JSON.stringify(responseBody));
+    }
+
+    // Write chunks in order, using writeAll to guard against short writes
+    try {
+      for (let i = 0; i < totalChunks; i++) {
+        const chunkBytes = await Deno.readFile(join(uploadDir, String(i)));
+        await writeAll(finalFile, chunkBytes);
+      }
+    } catch (error) {
+      finalFile.close();
+      await Deno.remove(finalFilePath).catch(() => {});
+      await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
+      throw error;
+    }
+
+    finalFile.close();
+    await Deno.remove(uploadDir, { recursive: true });
+
+    const newFiles = await FileModel.list(user!.id, pathInView);
+    const newDirectories = await DirectoryModel.list(user!.id, pathInView);
+
+    const responseBody: ResponseBody = { success: true, isComplete: true, newFiles, newDirectories };
+    return new Response(JSON.stringify(responseBody));
+  } catch (error) {
+    console.error(error);
+    await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
+    return new Response('Internal Server Error', { status: 500 });
+  }
+}
+
+export default page({
+  post,
+  accessMode: 'user',
+});

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -18,6 +18,7 @@ export default function MainFiles({
 }) {
   const isAdding = useSignal(false);
   const isUploading = useSignal(false);
+  const uploadProgress = useSignal('');
   const isDeleting = useSignal(false);
   const isUpdating = useSignal(false);
   const directories = useSignal(initialDirectories);
@@ -34,6 +35,61 @@ export default function MainFiles({
   const moveDirectoryOrFileModal = useSignal(null);
   const createShareModal = useSignal(null);
   const manageShareModal = useSignal(null);
+  const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+  async function uploadFileSingle(chosenFile, parentPath) {
+    const requestBody = new FormData();
+    requestBody.set('path_in_view', path.value);
+    requestBody.set('parent_path', parentPath);
+    requestBody.set('name', chosenFile.name);
+    requestBody.set('contents', chosenFile);
+    const response = await fetch(`/api/files/upload`, {
+      method: 'POST',
+      body: requestBody
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+    }
+    const result = await response.json();
+    if (!result.success) {
+      throw new Error('Failed to upload file!');
+    }
+    files.value = [...result.newFiles];
+    directories.value = [...result.newDirectories];
+  }
+  async function uploadFileChunked(chosenFile, parentPath) {
+    const totalChunks = Math.ceil(chosenFile.size / CHUNK_SIZE_BYTES);
+    const uploadId = crypto.randomUUID();
+    const pathInView = path.value;
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+      uploadProgress.value = `Uploading ${chosenFile.name} (${chunkIndex + 1}/${totalChunks})…`;
+      const start = chunkIndex * CHUNK_SIZE_BYTES;
+      const end = Math.min(start + CHUNK_SIZE_BYTES, chosenFile.size);
+      const chunkBlob = chosenFile.slice(start, end);
+      const requestBody = new FormData();
+      requestBody.set('upload_id', uploadId);
+      requestBody.set('chunk_index', String(chunkIndex));
+      requestBody.set('total_chunks', String(totalChunks));
+      requestBody.set('path_in_view', pathInView);
+      requestBody.set('parent_path', parentPath);
+      requestBody.set('name', chosenFile.name);
+      requestBody.set('chunk', chunkBlob);
+      const response = await fetch(`/api/files/upload-chunk`, {
+        method: 'POST',
+        body: requestBody
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`);
+      }
+      const result = await response.json();
+      if (!result.success) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+      }
+      if (result.isComplete) {
+        files.value = [...result.newFiles];
+        directories.value = [...result.newDirectories];
+      }
+    }
+  }
   function onClickUploadFile(uploadDirectory = false) {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -48,34 +104,23 @@ export default function MainFiles({
       const chosenFilesList = event.target?.files;
       const chosenFiles = Array.from(chosenFilesList);
       isUploading.value = true;
+      uploadProgress.value = '';
       for (const chosenFile of chosenFiles) {
         if (!chosenFile) {
           continue;
         }
         areNewOptionsOpen.value = false;
-        const requestBody = new FormData();
-        requestBody.set('path_in_view', path.value);
-        requestBody.set('parent_path', path.value);
-        requestBody.set('name', chosenFile.name);
-        requestBody.set('contents', chosenFile);
+        let fileParentPath = path.value;
         if (chosenFile.webkitRelativePath) {
           const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
-          requestBody.set('parent_path', `${path.value}${directoryPath}`);
+          fileParentPath = `${path.value}${directoryPath}`;
         }
         try {
-          const response = await fetch(`/api/files/upload`, {
-            method: 'POST',
-            body: requestBody
-          });
-          if (!response.ok) {
-            throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+          if (chosenFile.size >= CHUNK_SIZE_BYTES) {
+            await uploadFileChunked(chosenFile, fileParentPath);
+          } else {
+            await uploadFileSingle(chosenFile, fileParentPath);
           }
-          const result = await response.json();
-          if (!result.success) {
-            throw new Error('Failed to upload file!');
-          }
-          files.value = [...result.newFiles];
-          directories.value = [...result.newDirectories];
         } catch (error) {
           console.error(error);
         }
@@ -631,7 +676,7 @@ export default function MainFiles({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Uploading...") : null, isUpdating.value ? h(Fragment, null, h("img", {
+  }), uploadProgress.value || 'Uploading…') : null, isUpdating.value ? h(Fragment, null, h("img", {
     src: "/public/images/loading.svg",
     class: "white mr-2",
     width: 18,

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -115,6 +115,7 @@ export default function MainFiles({
           const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
           fileParentPath = `${path.value}${directoryPath}`;
         }
+        uploadProgress.value = '';
         try {
           if (chosenFile.size >= CHUNK_SIZE_BYTES) {
             await uploadFileChunked(chosenFile, fileParentPath);

--- a/routes.ts
+++ b/routes.ts
@@ -362,6 +362,7 @@ const routes: Routes = {
   apiFilesSearch: createPageRouteHandler('api/files/search.ts', '/api/files/search'),
   apiFilesUpdateShare: createPageRouteHandler('api/files/update-share.ts', '/api/files/update-share'),
   apiFilesUpload: createPageRouteHandler('api/files/upload.ts', '/api/files/upload'),
+  apiFilesUploadChunk: createPageRouteHandler('api/files/upload-chunk.ts', '/api/files/upload-chunk'),
 
   apiNewsAddFeed: createPageRouteHandler('api/news/add-feed.ts', '/api/news/add-feed'),
   apiNewsDeleteFeed: createPageRouteHandler('api/news/delete-feed.ts', '/api/news/delete-feed'),


### PR DESCRIPTION
## Summary

- Adds a new `POST /api/files/upload-chunk` endpoint that receives files in 10 MB chunks and assembles them server-side
- The web UI automatically uses chunked upload for files ≥ 10 MB; smaller files continue using the existing `/api/files/upload` endpoint unchanged
- Chunks are stored temporarily under `{filesRoot}/.chunk-uploads/{userId}/{uploadId}/` and cleaned up immediately after assembly (or after 24 h if the upload is abandoned)
- No new dependencies — uses only native Deno APIs and standard browser APIs (`File.slice`, `crypto.randomUUID`)

## Motivation

Users self-hosting behind Cloudflare Tunnel (and similar proxies) hit a hard 100 MB per-request limit, making it impossible to upload large files through the web UI. With 10 MB chunks each request stays well under any proxy limit, so files of any size can be uploaded.

As a side effect, peak server memory during upload drops from the full file size down to ~10 MB regardless of how large the file is, because the server only buffers one chunk at a time.

## How it works

**Client (`components/files/MainFiles.tsx`):**
1. If `file.size >= 10 MB`, generate a UUID upload ID and slice the file into 10 MB `Blob`s using `File.slice` (lazy — no full-file memory allocation)
2. POST each chunk sequentially with its index and total count; show progress: `Uploading video.mp4 (3/9)…`
3. On the final chunk response, refresh the directory listing

**Server (`pages/api/files/upload-chunk.ts`):**
1. Validate all fields; reject path traversal via the existing `ensureUserPathIsValidAndSecurelyAccessible` utility
2. Write the chunk to `{filesRoot}/.chunk-uploads/{userId}/{uploadId}/{chunkIndex}`
3. Count files in the upload dir — if all chunks are present, open the final file with `createNew: true` (same behaviour as the existing upload endpoint) and write chunks in order using a `writeAll` loop to guard against short writes
4. Clean up the temp dir; return `{ newFiles, newDirectories }` matching the existing upload response shape
5. On the first chunk of every new upload, evict any stale upload dirs older than 24 h for that user

## Test plan

- [x] Upload a file < 10 MB — should use the original single-request path, no change in behaviour
- [x] Upload a file ≥ 10 MB — should show chunk progress in the status bar and complete successfully
- [x] Upload a file via directory upload (webkitRelativePath) — directory structure should be preserved
- [x] Verify `{filesRoot}/.chunk-uploads/` is empty after a completed upload
- [x] Verify assembled file is not corrupted (checksum the uploaded file against the original)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)