### PR TITLE
Improvement: Directory Download Optimizations (continued)

### DIFF
--- a/lib/models/files.ts
+++ b/lib/models/files.ts
@@ -796,7 +796,7 @@ async function getDirectorySizeFallback(path: string): Promise<number> {
 }
 
 // NOTE: We're using `-h` (human readable) and parsing the output because that's more stable than `-B 1B` across different systems for a reliable byte size.
-async function getDirectorySize(path: string): Promise<number> {
+export async function getDirectorySize(path: string): Promise<number> {
   try {
     const controller = new AbortController();
     const commandTimeout = setTimeout(() => controller.abort(), 5_000);

--- a/pages/api/files/download-directory.ts
+++ b/pages/api/files/download-directory.ts
@@ -38,25 +38,37 @@ async function get({ request, user }: RequestHandlerParams) {
     const userRootPath = join(filesRootPath, user!.id);
     const fullDirectoryPath = join(userRootPath, directoryPath);
 
-    // Use the zip command to create the archive
+    // Use the zip command to create the archive, streaming its stdout straight to the client
+    // instead of buffering the whole archive in memory. `-1` = fastest compression.
     const zipProcess = new Deno.Command('zip', {
-      args: ['-r', '-', '.'],
+      args: ['-r', '-1', '-', '.'],
       cwd: fullDirectoryPath,
       stdout: 'piped',
       stderr: 'piped',
     });
 
-    const { code, stdout, stderr } = await zipProcess.output();
+    const child = zipProcess.spawn();
 
-    if (code !== 0) {
-      const errorText = new TextDecoder().decode(stderr);
+    // Consume stderr in the background so a full stderr buffer can't block the child
+    new Response(child.stderr).text().then((text) => {
+      if (text.trim()) {
+        console.error('Zip command stderr:', text);
+      }
+    }).catch(() => {});
 
-      console.error('Zip command failed:', errorText);
+    // Reap the process in the background to avoid a lingering child
+    child.status.catch(() => {});
 
-      return new Response('Error creating zip archive', { status: 500 });
-    }
+    // Kill the child if the client disconnects mid-download, to avoid an orphaned `zip` process
+    request.signal.addEventListener('abort', () => {
+      try {
+        child.kill();
+      } catch {
+        // Already exited, ignore
+      }
+    });
 
-    return new Response(stdout, {
+    return new Response(child.stdout, {
       status: 200,
       headers: {
         'content-type': 'application/zip',

--- a/pages/api/files/download-directory.ts
+++ b/pages/api/files/download-directory.ts
@@ -49,6 +49,11 @@ async function get({ request, user }: RequestHandlerParams) {
         return new Response('Not a directory', { status: 400 });
       }
     } catch (error) {
+      if (error instanceof Deno.errors.PermissionDenied) {
+        console.error('Permission denied accessing directory for zip download:', error);
+        return new Response('Forbidden', { status: 403 });
+      }
+
       console.error('Directory not accessible for zip download:', error);
       return new Response('Directory not found', { status: 404 });
     }

--- a/pages/api/files/download-directory.ts
+++ b/pages/api/files/download-directory.ts
@@ -2,7 +2,10 @@ import page, { RequestHandlerParams } from '/lib/page.ts';
 import { join } from '@std/path';
 
 import { AppConfig } from '/lib/config.ts';
-import { ensureUserPathIsValidAndSecurelyAccessible } from '/lib/models/files.ts';
+import { ensureUserPathIsValidAndSecurelyAccessible, getDirectorySize } from '/lib/models/files.ts';
+
+// -1 (fastest compression) trades compression ratio for CPU time, so only use it once the directory is big enough for that to matter
+const FAST_COMPRESSION_MIN_SIZE_IN_BYTES = 10 * 1024 * 1024; // 10MB
 
 async function get({ request, user }: RequestHandlerParams) {
   const config = await AppConfig.getConfig();
@@ -38,26 +41,50 @@ async function get({ request, user }: RequestHandlerParams) {
     const userRootPath = join(filesRootPath, user!.id);
     const fullDirectoryPath = join(userRootPath, directoryPath);
 
-    // Use the zip command to create the archive, streaming its stdout straight to the client
-    // instead of buffering the whole archive in memory. `-1` = fastest compression.
-    const zipProcess = new Deno.Command('zip', {
-      args: ['-r', '-1', '-', '.'],
-      cwd: fullDirectoryPath,
-      stdout: 'piped',
-      stderr: 'piped',
-    });
+    // Pre-flight: directory must exist and be readable before we spawn zip
+    try {
+      const directoryStat = await Deno.stat(fullDirectoryPath);
 
-    const child = zipProcess.spawn();
+      if (!directoryStat.isDirectory) {
+        return new Response('Not a directory', { status: 400 });
+      }
+    } catch (error) {
+      console.error('Directory not accessible for zip download:', error);
+      return new Response('Directory not found', { status: 404 });
+    }
+
+    const directorySizeInBytes = await getDirectorySize(fullDirectoryPath);
+    const compressionArgs = directorySizeInBytes > FAST_COMPRESSION_MIN_SIZE_IN_BYTES ? ['-1'] : [];
+
+    // Use the zip command to create the archive, streaming its stdout straight to the client instead of buffering the whole archive in memory
+    let child: Deno.ChildProcess;
+    try {
+      child = new Deno.Command('zip', {
+        args: ['-r', ...compressionArgs, '-', '.'],
+        cwd: fullDirectoryPath,
+        stdout: 'piped',
+        stderr: 'piped',
+      }).spawn();
+    } catch (error) {
+      console.error('zip command is not available:', error);
+      return new Response('Error creating zip archive', { status: 500 });
+    }
+
+    let stderrText = '';
 
     // Consume stderr in the background so a full stderr buffer can't block the child
-    new Response(child.stderr).text().then((text) => {
-      if (text.trim()) {
-        console.error('Zip command stderr:', text);
-      }
-    }).catch(() => {});
+    const consumeStderr = async () => {
+      try {
+        stderrText = await new Response(child.stderr).text();
 
-    // Reap the process in the background to avoid a lingering child
-    child.status.catch(() => {});
+        if (stderrText.trim()) {
+          console.error('Zip command stderr:', stderrText);
+        }
+      } catch (error) {
+        console.error('Failed to read zip stderr:', error);
+      }
+    };
+    consumeStderr();
 
     // Kill the child if the client disconnects mid-download, to avoid an orphaned `zip` process
     request.signal.addEventListener('abort', () => {
@@ -68,7 +95,38 @@ async function get({ request, user }: RequestHandlerParams) {
       }
     });
 
-    return new Response(child.stdout, {
+    // Wrap stdout so a non-zero zip exit propagates as a stream error instead of a silently-truncated "successful" download
+    const stdoutReader = child.stdout.getReader();
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const { done, value } = await stdoutReader.read();
+
+        if (done) {
+          const status = await child.status;
+
+          if (!status.success) {
+            console.error(`Zip command exited with code ${status.code}: ${stderrText}`);
+            controller.error(new Error(`zip exited with code ${status.code}`));
+            return;
+          }
+
+          controller.close();
+          return;
+        }
+
+        controller.enqueue(value);
+      },
+      cancel(reason) {
+        stdoutReader.cancel(reason).catch(() => {});
+        try {
+          child.kill();
+        } catch {
+          // Already exited, ignore
+        }
+      },
+    });
+
+    return new Response(stream, {
       status: 200,
       headers: {
         'content-type': 'application/zip',

--- a/pages/api/files/download-directory.ts
+++ b/pages/api/files/download-directory.ts
@@ -89,7 +89,7 @@ async function get({ request, user }: RequestHandlerParams) {
         console.error('Failed to read zip stderr:', error);
       }
     };
-    consumeStderr();
+    const stderrPromise = consumeStderr();
 
     // Kill the child if the client disconnects mid-download, to avoid an orphaned `zip` process
     request.signal.addEventListener('abort', () => {
@@ -107,7 +107,7 @@ async function get({ request, user }: RequestHandlerParams) {
         const { done, value } = await stdoutReader.read();
 
         if (done) {
-          const status = await child.status;
+          const [status] = await Promise.all([child.status, stderrPromise]);
 
           if (!status.success) {
             console.error(`Zip command exited with code ${status.code}: ${stderrText}`);


### PR DESCRIPTION
Continuing on my improvements from last year (#119), the directory download now streams directly to the response instead of loading the zip into memory on the server first. This also contains the feedback not to use JSZip from the previous PR.

In my testing, this has shown great improvements for multi-gigabyte directories, whereas, without this improvement, my server would always crash.