### PR TITLE
Feature: Implement service worker for uploads

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,15 +1,18 @@
-// Converts local TSX imports to JS imports, used in the components
-const rewriteLocalTsxImports = () => {
+// Converts local TS/TSX imports to JS imports, used in the components
+const rewriteLocalTypeScriptImports = () => {
   const isLocal = (value) => typeof value === 'string' && (value.startsWith('./') || value.startsWith('../'));
   const isComponent = (value) => typeof value === 'string' && value.startsWith('/components/');
+  // Every component is compiled to a .js file next to this one, and only /public/ is served, so both extensions have to point there or the browser gets a 404
+  const isTypeScript = (value) => typeof value === 'string' && (value.endsWith('.ts') || value.endsWith('.tsx'));
+  const toJsFileName = (value) => `${value.slice(0, value.lastIndexOf('.'))}.js`;
 
   const rewrite = (source) => {
-    if (source && isLocal(source.value) && source.value.endsWith('.tsx')) {
-      source.value = source.value.replace('.tsx', '.js');
+    if (source && isLocal(source.value) && isTypeScript(source.value)) {
+      source.value = toJsFileName(source.value);
     }
 
-    if (source && isComponent(source.value) && source.value.endsWith('.tsx')) {
-      source.value = source.value.replace('/components/', '/public/components/').replace('.tsx', '.js');
+    if (source && isComponent(source.value) && isTypeScript(source.value)) {
+      source.value = toJsFileName(source.value.replace('/components/', '/public/components/'));
     }
   };
 
@@ -34,7 +37,7 @@ const presets = [
 ];
 
 const plugins = [
-  rewriteLocalTsxImports,
+  rewriteLocalTypeScriptImports,
   [
     '@babel/plugin-transform-react-jsx',
     {

--- a/babel.config_test.ts
+++ b/babel.config_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from '@std/assert';
+import { walk } from '@std/fs';
+import { dirname, fromFileUrl, join, resolve } from '@std/path';
+
+const rootPath = dirname(fromFileUrl(import.meta.url));
+const compiledComponentsPath = join(rootPath, 'public', 'components');
+
+// The browser only gets what's under /public/, so a compiled component importing a .ts/.tsx path (or anything else that isn't there) 404s and leaves the page stuck on its loading state
+Deno.test('that compiled components only import files that are actually served', async () => {
+  const brokenImports: string[] = [];
+
+  for await (const entry of walk(compiledComponentsPath, { exts: ['.js'] })) {
+    const fileContents = await Deno.readTextFile(entry.path);
+
+    for (const match of fileContents.matchAll(/(?:from|import)\s*["']([^"']+)["']/g)) {
+      const importedPath = match[1];
+
+      const absolutePath = importedPath.startsWith('/public/')
+        ? join(rootPath, importedPath)
+        : importedPath.startsWith('.')
+        ? resolve(dirname(entry.path), importedPath)
+        // Bare specifiers come from the import map, and /public/ts/ files are transpiled on the fly when requested
+        : '';
+
+      if (!absolutePath) {
+        continue;
+      }
+
+      try {
+        await Deno.stat(absolutePath);
+      } catch {
+        brokenImports.push(`${entry.path} imports ${importedPath}`);
+      }
+    }
+  }
+
+  assertEquals(brokenImports, []);
+});

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -105,6 +105,7 @@ export default function Header({ route, user, enabledApps }: Data) {
                   </a>
                   <a
                     href='/logout'
+                    id='logout-link'
                     class={defaultClass}
                   >
                     <img

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -1,4 +1,5 @@
 import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
 
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { SortColumn, sortDirectories, sortFiles, SortOrder } from '/public/ts/utils/files.ts';
@@ -94,6 +95,62 @@ export default function MainFiles(
   >(null);
   const createShareModal = useSignal<{ isOpen: boolean; filePath: string; password?: string } | null>(null);
   const manageShareModal = useSignal<{ isOpen: boolean; fileShareId: string } | null>(null);
+
+  // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
+  useEffect(() => {
+    if (fileShareId || !('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const uploadChannel = new BroadcastChannel('bewcloud-uploads');
+
+    uploadChannel.onmessage = (event) => {
+      const state = event.data as {
+        type: string;
+        isUploading: boolean;
+        uploadProgress: string;
+        newFiles?: DirectoryFile[];
+        newDirectories?: Directory[];
+        pathInView?: string;
+        error?: string;
+      };
+
+      if (!state || state.type !== 'STATE') {
+        return;
+      }
+
+      isUploading.value = state.isUploading;
+      uploadProgress.value = state.uploadProgress || '';
+
+      if (state.error) {
+        console.error(new Error(state.error));
+      }
+
+      // Only apply the file/directory listing from an upload if it matches this tab's own current path; another tab may have uploaded into a different directory.
+      if (state.newFiles && state.pathInView === path.value) {
+        files.value = [...state.newFiles];
+      }
+
+      if (state.newDirectories && state.pathInView === path.value) {
+        directories.value = [...state.newDirectories];
+      }
+    };
+
+    async function queryUploadState() {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        registration.active?.postMessage({ type: 'QUERY_STATE' });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    queryUploadState();
+
+    return () => {
+      uploadChannel.close();
+    };
+  }, []);
 
   function onClickSort(column: SortColumn) {
     let newSortOrder: SortOrder = 'asc';
@@ -217,25 +274,45 @@ export default function MainFiles(
 
       const chosenFiles = Array.from(chosenFilesList);
 
+      if (chosenFiles.length === 0) {
+        return;
+      }
+
+      areNewOptionsOpen.value = false;
       isUploading.value = true;
       uploadProgress.value = '';
 
+      // Capture once: the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
+      const pathInView = path.value;
+
+      function getFileParentPath(chosenFile: File) {
+        if (!chosenFile.webkitRelativePath) {
+          return pathInView;
+        }
+
+        // Resolve the parent path, keeping any sub-directory structure from directory uploads.
+        // We don't need to worry about path joining here, the API will handle it (and make sure it's secure)
+        const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
+        return `${pathInView}${directoryPath}`;
+      }
+
+      const serviceWorker = navigator.serviceWorker?.controller;
+
+      if (serviceWorker) {
+        const items = chosenFiles.map((chosenFile) => ({
+          file: chosenFile,
+          parentPath: getFileParentPath(chosenFile),
+          pathInView,
+        }));
+
+        serviceWorker.postMessage({ type: 'ENQUEUE_UPLOAD', items });
+
+        return;
+      }
+
+      // Fallback for browsers/contexts without an active service worker: upload directly, as before.
       for (const chosenFile of chosenFiles) {
-        if (!chosenFile) {
-          continue;
-        }
-
-        areNewOptionsOpen.value = false;
-
-        // Resolve the parent path, keeping any sub-directory structure from directory uploads
-        let fileParentPath = path.value;
-        if (chosenFile.webkitRelativePath) {
-          const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
-          // We don't need to worry about path joining here, the API will handle it (and make sure it's secure)
-          fileParentPath = `${path.value}${directoryPath}`;
-        }
-
-        uploadProgress.value = '';
+        const fileParentPath = getFileParentPath(chosenFile);
 
         try {
           if (chosenFile.size >= CHUNK_SIZE_BYTES) {

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -53,6 +53,7 @@ interface MainFilesProps {
   fileShareId?: string;
   initialSortBy?: SortColumn;
   initialSortOrder?: SortOrder;
+  uploadSessionTag?: string;
 }
 
 export default function MainFiles(
@@ -66,6 +67,7 @@ export default function MainFiles(
     fileShareId,
     initialSortBy = 'name',
     initialSortOrder = 'asc',
+    uploadSessionTag,
   }: MainFilesProps,
 ) {
   const isAdding = useSignal<boolean>(false);
@@ -92,11 +94,12 @@ export default function MainFiles(
   const createShareModal = useSignal<{ isOpen: boolean; filePath: string; password?: string } | null>(null);
   const manageShareModal = useSignal<{ isOpen: boolean; fileShareId: string } | null>(null);
 
-  const { isUploading, uploadProgress, enqueueUpload } = useUploadQueue({
+  const { isUploading, uploadProgress, uploadError, enqueueUpload } = useUploadQueue({
     isEnabled: !fileShareId,
     path,
     files,
     directories,
+    uploadSessionTag,
   });
 
   function onClickSort(column: SortColumn) {
@@ -918,6 +921,14 @@ export default function MainFiles(
             : null}
           {!isDeleting.value && !isAdding.value && !isUploading.value && !isUpdating.value ? <>&nbsp;</> : null}
         </span>
+
+        {uploadError.value
+          ? (
+            <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
+              Upload failed — {uploadError.value}
+            </span>
+          )
+          : null}
       </section>
 
       {!fileShareId

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -1,10 +1,7 @@
 import { useSignal } from '@preact/signals';
-import { useEffect } from 'preact/hooks';
 
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { SortColumn, sortDirectories, sortFiles, SortOrder } from '/public/ts/utils/files.ts';
-import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
-import { ResponseBody as ChunkUploadResponseBody } from '/pages/api/files/upload-chunk.ts';
 import { RequestBody as RenameRequestBody, ResponseBody as RenameResponseBody } from '/pages/api/files/rename.ts';
 import { RequestBody as MoveRequestBody, ResponseBody as MoveResponseBody } from '/pages/api/files/move.ts';
 import { RequestBody as DeleteRequestBody, ResponseBody as DeleteResponseBody } from '/pages/api/files/delete.ts';
@@ -36,6 +33,7 @@ import {
   RequestBody as DeleteShareRequestBody,
   ResponseBody as DeleteShareResponseBody,
 } from '/pages/api/files/delete-share.ts';
+import { useUploadQueue } from './useUploadQueue.ts';
 import SearchFiles from './SearchFiles.tsx';
 import ListFiles from './ListFiles.tsx';
 import FilesBreadcrumb from './FilesBreadcrumb.tsx';
@@ -71,8 +69,6 @@ export default function MainFiles(
   }: MainFilesProps,
 ) {
   const isAdding = useSignal<boolean>(false);
-  const isUploading = useSignal<boolean>(false);
-  const uploadProgress = useSignal<string>('');
   const isDeleting = useSignal<boolean>(false);
   const isUpdating = useSignal<boolean>(false);
   const directories = useSignal<Directory[]>(initialDirectories);
@@ -96,61 +92,12 @@ export default function MainFiles(
   const createShareModal = useSignal<{ isOpen: boolean; filePath: string; password?: string } | null>(null);
   const manageShareModal = useSignal<{ isOpen: boolean; fileShareId: string } | null>(null);
 
-  // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
-  useEffect(() => {
-    if (fileShareId || !('serviceWorker' in navigator)) {
-      return;
-    }
-
-    const uploadChannel = new BroadcastChannel('bewcloud-uploads');
-
-    uploadChannel.onmessage = (event) => {
-      const state = event.data as {
-        type: string;
-        isUploading: boolean;
-        uploadProgress: string;
-        newFiles?: DirectoryFile[];
-        newDirectories?: Directory[];
-        pathInView?: string;
-        error?: string;
-      };
-
-      if (!state || state.type !== 'STATE') {
-        return;
-      }
-
-      isUploading.value = state.isUploading;
-      uploadProgress.value = state.uploadProgress || '';
-
-      if (state.error) {
-        console.error(new Error(state.error));
-      }
-
-      // Only apply the file/directory listing from an upload if it matches this tab's own current path; another tab may have uploaded into a different directory.
-      if (state.newFiles && state.pathInView === path.value) {
-        files.value = [...state.newFiles];
-      }
-
-      if (state.newDirectories && state.pathInView === path.value) {
-        directories.value = [...state.newDirectories];
-      }
-    };
-
-    async function queryUploadState() {
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        registration.active?.postMessage({ type: 'QUERY_STATE' });
-      } catch (error) {
-        console.error(error);
-      }
-    }
-
-    queryUploadState();
-
-    return () => {
-      uploadChannel.close();
-    };
-  }, []);
+  const { isUploading, uploadProgress, enqueueUpload } = useUploadQueue({
+    isEnabled: !fileShareId,
+    path,
+    files,
+    directories,
+  });
 
   function onClickSort(column: SortColumn) {
     let newSortOrder: SortOrder = 'asc';
@@ -181,81 +128,6 @@ export default function MainFiles(
     }
   }
 
-  // 10 MB chunks keep each request faster.
-  const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
-
-  async function uploadFileSingle(chosenFile: File, parentPath: string) {
-    const requestBody = new FormData();
-    requestBody.set('path_in_view', path.value);
-    requestBody.set('parent_path', parentPath);
-    requestBody.set('name', chosenFile.name);
-    requestBody.set('contents', chosenFile);
-
-    const response = await fetch(`/api/files/upload`, {
-      method: 'POST',
-      body: requestBody,
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
-    }
-
-    const result = await response.json() as UploadResponseBody;
-
-    if (!result.success) {
-      throw new Error('Failed to upload file!');
-    }
-
-    files.value = [...result.newFiles];
-    directories.value = [...result.newDirectories];
-  }
-
-  async function uploadFileChunked(chosenFile: File, parentPath: string) {
-    const totalChunks = Math.ceil(chosenFile.size / CHUNK_SIZE_BYTES);
-    const uploadId = crypto.randomUUID();
-    // Capture once — the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
-    const pathInView = path.value;
-
-    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-      uploadProgress.value = `Uploading ${chosenFile.name} (${chunkIndex + 1}/${totalChunks})…`;
-
-      const start = chunkIndex * CHUNK_SIZE_BYTES;
-      const end = Math.min(start + CHUNK_SIZE_BYTES, chosenFile.size);
-      const chunkBlob = chosenFile.slice(start, end);
-
-      const requestBody = new FormData();
-      requestBody.set('upload_id', uploadId);
-      requestBody.set('chunk_index', String(chunkIndex));
-      requestBody.set('total_chunks', String(totalChunks));
-      requestBody.set('path_in_view', pathInView);
-      requestBody.set('parent_path', parentPath);
-      requestBody.set('name', chosenFile.name);
-      requestBody.set('chunk', chunkBlob);
-
-      const response = await fetch(`/api/files/upload-chunk`, {
-        method: 'POST',
-        body: requestBody,
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`,
-        );
-      }
-
-      const result = await response.json() as ChunkUploadResponseBody;
-
-      if (!result.success) {
-        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
-      }
-
-      if (result.isComplete) {
-        files.value = [...result.newFiles!];
-        directories.value = [...result.newDirectories!];
-      }
-    }
-  }
-
   function onClickUploadFile(uploadDirectory = false) {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -269,7 +141,7 @@ export default function MainFiles(
     }
     fileInput.click();
 
-    fileInput.onchange = async (event) => {
+    fileInput.onchange = (event) => {
       const chosenFilesList = (event.target as HTMLInputElement)?.files!;
 
       const chosenFiles = Array.from(chosenFilesList);
@@ -279,53 +151,22 @@ export default function MainFiles(
       }
 
       areNewOptionsOpen.value = false;
-      isUploading.value = true;
-      uploadProgress.value = '';
-
-      // Capture once: the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
-      const pathInView = path.value;
 
       function getFileParentPath(chosenFile: File) {
         if (!chosenFile.webkitRelativePath) {
-          return pathInView;
+          return path.value;
         }
 
         // Resolve the parent path, keeping any sub-directory structure from directory uploads.
         // We don't need to worry about path joining here, the API will handle it (and make sure it's secure)
         const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
-        return `${pathInView}${directoryPath}`;
+        return `${path.value}${directoryPath}`;
       }
 
-      const serviceWorker = navigator.serviceWorker?.controller;
-
-      if (serviceWorker) {
-        const items = chosenFiles.map((chosenFile) => ({
-          file: chosenFile,
-          parentPath: getFileParentPath(chosenFile),
-          pathInView,
-        }));
-
-        serviceWorker.postMessage({ type: 'ENQUEUE_UPLOAD', items });
-
-        return;
-      }
-
-      // Fallback for browsers/contexts without an active service worker: upload directly, as before.
-      for (const chosenFile of chosenFiles) {
-        const fileParentPath = getFileParentPath(chosenFile);
-
-        try {
-          if (chosenFile.size >= CHUNK_SIZE_BYTES) {
-            await uploadFileChunked(chosenFile, fileParentPath);
-          } else {
-            await uploadFileSingle(chosenFile, fileParentPath);
-          }
-        } catch (error) {
-          console.error(error);
-        }
-      }
-
-      isUploading.value = false;
+      enqueueUpload(chosenFiles.map((chosenFile) => ({
+        file: chosenFile,
+        parentPath: getFileParentPath(chosenFile),
+      })));
     };
   }
 

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -477,6 +477,13 @@ export default function MainFiles(
         }
 
         directories.value = [...result.newDirectories];
+
+        // Tell the service worker to drop it instead of letting it keep going. Any queued upload still writing into this directory (or a subdirectory of it) is now writing into nothing.
+        navigator.serviceWorker?.controller?.postMessage({
+          type: 'DIRECTORY_DELETED',
+          sessionTag: uploadSessionTag,
+          path: `${parentPath}${name}/`,
+        });
       } catch (error) {
         console.error(error);
       }

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -33,7 +33,7 @@ import {
   RequestBody as DeleteShareRequestBody,
   ResponseBody as DeleteShareResponseBody,
 } from '/pages/api/files/delete-share.ts';
-import { useUploadQueue } from './useUploadQueue.ts';
+import { postToUploadServiceWorker, useUploadQueue } from './useUploadQueue.ts';
 import SearchFiles from './SearchFiles.tsx';
 import ListFiles from './ListFiles.tsx';
 import FilesBreadcrumb from './FilesBreadcrumb.tsx';
@@ -479,9 +479,9 @@ export default function MainFiles(
         directories.value = [...result.newDirectories];
 
         // Tell the service worker to drop it instead of letting it keep going. Any queued upload still writing into this directory (or a subdirectory of it) is now writing into nothing.
-        navigator.serviceWorker?.controller?.postMessage({
+        await postToUploadServiceWorker({
           type: 'DIRECTORY_DELETED',
-          sessionTag: uploadSessionTag,
+          sessionTag: uploadSessionTag ?? '',
           path: `${parentPath}${name}/`,
         });
       } catch (error) {

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -100,6 +100,7 @@ export default function MainFiles(
     files,
     directories,
     uploadSessionTag,
+    uploadKind: 'file',
   });
 
   function onClickSort(column: SortColumn) {

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -18,12 +18,14 @@ interface UseUploadQueueOptions {
   path: Signal<string>;
   files: Signal<DirectoryFile[]>;
   directories: Signal<Directory[]>;
+  uploadSessionTag?: string;
 }
 
 // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
-export function useUploadQueue({ isEnabled, path, files, directories }: UseUploadQueueOptions) {
+export function useUploadQueue({ isEnabled, path, files, directories, uploadSessionTag = '' }: UseUploadQueueOptions) {
   const isUploading = useSignal<boolean>(false);
   const uploadProgress = useSignal<string>('');
+  const uploadError = useSignal<string>('');
 
   useEffect(() => {
     if (!isEnabled || !('serviceWorker' in navigator)) {
@@ -41,9 +43,14 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
         newDirectories?: Directory[];
         pathInView?: string;
         error?: string;
+        sessionTag?: string;
       };
 
       if (!state || state.type !== 'STATE') {
+        return;
+      }
+
+      if (state.sessionTag && state.sessionTag !== uploadSessionTag) {
         return;
       }
 
@@ -52,6 +59,7 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
 
       if (state.error) {
         console.error(new Error(state.error));
+        uploadError.value = state.error;
       }
 
       // Only apply the file/directory listing from an upload if it matches this tab's own current path; another tab may have uploaded into a different directory.
@@ -67,7 +75,7 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
     async function queryUploadState() {
       try {
         const registration = await navigator.serviceWorker.ready;
-        registration.active?.postMessage({ type: 'QUERY_STATE' });
+        registration.active?.postMessage({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });
       } catch (error) {
         console.error(error);
       }
@@ -85,6 +93,7 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
     requestBody.set('path_in_view', pathInView);
     requestBody.set('parent_path', parentPath);
     requestBody.set('name', file.name);
+    requestBody.set('upload_session_tag', uploadSessionTag);
     requestBody.set('contents', file);
 
     const response = await fetch(`/api/files/upload`, {
@@ -124,6 +133,7 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
       requestBody.set('path_in_view', pathInView);
       requestBody.set('parent_path', parentPath);
       requestBody.set('name', file.name);
+      requestBody.set('upload_session_tag', uploadSessionTag);
       requestBody.set('chunk', chunkBlob);
 
       const response = await fetch(`/api/files/upload-chunk`, {
@@ -160,12 +170,14 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
 
     isUploading.value = true;
     uploadProgress.value = '';
+    uploadError.value = '';
 
     const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
 
     if (serviceWorker) {
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
+        sessionTag: uploadSessionTag,
         items: items.map((item) => ({ ...item, pathInView })),
       });
 
@@ -183,6 +195,7 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
           }
         } catch (error) {
           console.error(error);
+          uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
         }
       }
 
@@ -190,5 +203,5 @@ export function useUploadQueue({ isEnabled, path, files, directories }: UseUploa
     })();
   }
 
-  return { isUploading, uploadProgress, enqueueUpload };
+  return { isUploading, uploadProgress, uploadError, enqueueUpload };
 }

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -108,7 +108,7 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
     const result = await response.json() as UploadResponseBody;
 
     if (!result.success) {
-      throw new Error('Failed to upload file!');
+      throw new Error(result.error || 'Failed to upload file!');
     }
 
     files.value = [...result.newFiles];
@@ -150,7 +150,7 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
       const result = await response.json() as ChunkUploadResponseBody;
 
       if (!result.success) {
-        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+        throw new Error(result.error || `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
       }
 
       if (result.isComplete) {

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -1,0 +1,194 @@
+import { Signal, useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+
+import { Directory, DirectoryFile } from '/lib/types.ts';
+import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
+import { ResponseBody as ChunkUploadResponseBody } from '/pages/api/files/upload-chunk.ts';
+
+// 10 MB chunks keep each request faster.
+const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+
+interface UploadQueueItem {
+  file: File;
+  parentPath: string;
+}
+
+interface UseUploadQueueOptions {
+  isEnabled: boolean;
+  path: Signal<string>;
+  files: Signal<DirectoryFile[]>;
+  directories: Signal<Directory[]>;
+}
+
+// Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
+export function useUploadQueue({ isEnabled, path, files, directories }: UseUploadQueueOptions) {
+  const isUploading = useSignal<boolean>(false);
+  const uploadProgress = useSignal<string>('');
+
+  useEffect(() => {
+    if (!isEnabled || !('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const uploadChannel = new BroadcastChannel('bewcloud-uploads');
+
+    uploadChannel.onmessage = (event) => {
+      const state = event.data as {
+        type: string;
+        isUploading: boolean;
+        uploadProgress: string;
+        newFiles?: DirectoryFile[];
+        newDirectories?: Directory[];
+        pathInView?: string;
+        error?: string;
+      };
+
+      if (!state || state.type !== 'STATE') {
+        return;
+      }
+
+      isUploading.value = state.isUploading;
+      uploadProgress.value = state.uploadProgress || '';
+
+      if (state.error) {
+        console.error(new Error(state.error));
+      }
+
+      // Only apply the file/directory listing from an upload if it matches this tab's own current path; another tab may have uploaded into a different directory.
+      if (state.newFiles && state.pathInView === path.value) {
+        files.value = [...state.newFiles];
+      }
+
+      if (state.newDirectories && state.pathInView === path.value) {
+        directories.value = [...state.newDirectories];
+      }
+    };
+
+    async function queryUploadState() {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        registration.active?.postMessage({ type: 'QUERY_STATE' });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    queryUploadState();
+
+    return () => {
+      uploadChannel.close();
+    };
+  }, []);
+
+  async function uploadFileSingle(file: File, parentPath: string, pathInView: string) {
+    const requestBody = new FormData();
+    requestBody.set('path_in_view', pathInView);
+    requestBody.set('parent_path', parentPath);
+    requestBody.set('name', file.name);
+    requestBody.set('contents', file);
+
+    const response = await fetch(`/api/files/upload`, {
+      method: 'POST',
+      body: requestBody,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+    }
+
+    const result = await response.json() as UploadResponseBody;
+
+    if (!result.success) {
+      throw new Error('Failed to upload file!');
+    }
+
+    files.value = [...result.newFiles];
+    directories.value = [...result.newDirectories];
+  }
+
+  async function uploadFileChunked(file: File, parentPath: string, pathInView: string) {
+    const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
+    const uploadId = crypto.randomUUID();
+
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+      uploadProgress.value = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+
+      const start = chunkIndex * CHUNK_SIZE_BYTES;
+      const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
+      const chunkBlob = file.slice(start, end);
+
+      const requestBody = new FormData();
+      requestBody.set('upload_id', uploadId);
+      requestBody.set('chunk_index', String(chunkIndex));
+      requestBody.set('total_chunks', String(totalChunks));
+      requestBody.set('path_in_view', pathInView);
+      requestBody.set('parent_path', parentPath);
+      requestBody.set('name', file.name);
+      requestBody.set('chunk', chunkBlob);
+
+      const response = await fetch(`/api/files/upload-chunk`, {
+        method: 'POST',
+        body: requestBody,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`,
+        );
+      }
+
+      const result = await response.json() as ChunkUploadResponseBody;
+
+      if (!result.success) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+      }
+
+      if (result.isComplete) {
+        files.value = [...result.newFiles!];
+        directories.value = [...result.newDirectories!];
+      }
+    }
+  }
+
+  function enqueueUpload(items: UploadQueueItem[]) {
+    if (items.length === 0) {
+      return;
+    }
+
+    // Capture once: the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
+    const pathInView = path.value;
+
+    isUploading.value = true;
+    uploadProgress.value = '';
+
+    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
+
+    if (serviceWorker) {
+      serviceWorker.postMessage({
+        type: 'ENQUEUE_UPLOAD',
+        items: items.map((item) => ({ ...item, pathInView })),
+      });
+
+      return;
+    }
+
+    // Fallback for browsers/contexts without an active service worker: upload directly, as before.
+    (async () => {
+      for (const item of items) {
+        try {
+          if (item.file.size >= CHUNK_SIZE_BYTES) {
+            await uploadFileChunked(item.file, item.parentPath, pathInView);
+          } else {
+            await uploadFileSingle(item.file, item.parentPath, pathInView);
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      isUploading.value = false;
+    })();
+  }
+
+  return { isUploading, uploadProgress, enqueueUpload };
+}

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -60,7 +60,7 @@ export function useUploadQueue(
         return;
       }
 
-      isUploading.value = Boolean(state.kindsInProgress?.includes(uploadKind));
+      isUploading.value = state.kindsInProgress ? state.kindsInProgress.includes(uploadKind) : state.isUploading;
       uploadProgress.value = state.kind === uploadKind ? (state.uploadProgress || '') : '';
 
       if (state.error && state.kind === uploadKind) {
@@ -171,7 +171,12 @@ export function useUploadQueue(
     try {
       const requestBody: GetFilesRequestBody = { parentPath };
 
-      const response = await fetch('/api/files/get', { method: 'POST', body: JSON.stringify(requestBody) });
+      // Same reasoning as sw.js's fetchForJob: don't let a hung server response block the upload from ever starting.
+      const response = await fetch('/api/files/get', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+        signal: AbortSignal.timeout(10_000),
+      });
 
       if (!response.ok) {
         return new Set();
@@ -191,6 +196,9 @@ export function useUploadQueue(
     if (items.length === 0) {
       return;
     }
+
+    // Capture once, before any await: the user may navigate away while the pre-upload existence check or the upload itself is in flight, which would change path.value and cause the eventual response to refresh the wrong directory listing.
+    const pathInView = path.value;
 
     isUploading.value = true;
     uploadProgress.value = '';
@@ -216,9 +224,6 @@ export function useUploadQueue(
       isUploading.value = false;
       return;
     }
-
-    // Capture once: the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
-    const pathInView = path.value;
 
     const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
 

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -19,6 +19,7 @@ interface UseUploadQueueOptions {
   files: Signal<DirectoryFile[]>;
   directories: Signal<Directory[]>;
   uploadSessionTag?: string;
+  uploadKind?: 'upload' | 'note';
 }
 
 // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
@@ -54,8 +55,8 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
         return;
       }
 
-      isUploading.value = state.isUploading;
-      uploadProgress.value = state.uploadProgress || '';
+      isUploading.value = Boolean(state.kindsInProgress?.includes(uploadKind));
+      uploadProgress.value = state.kind === uploadKind ? (state.uploadProgress || '') : '';
 
       if (state.error) {
         console.error(new Error(state.error));

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -23,7 +23,9 @@ interface UseUploadQueueOptions {
 }
 
 // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
-export function useUploadQueue({ isEnabled, path, files, directories, uploadSessionTag = '' }: UseUploadQueueOptions) {
+export function useUploadQueue(
+  { isEnabled, path, files, directories, uploadSessionTag = '', uploadKind = 'upload' }: UseUploadQueueOptions,
+) {
   const isUploading = useSignal<boolean>(false);
   const uploadProgress = useSignal<string>('');
   const uploadError = useSignal<string>('');
@@ -40,6 +42,8 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
         type: string;
         isUploading: boolean;
         uploadProgress: string;
+        kindsInProgress?: string[];
+        kind?: string;
         newFiles?: DirectoryFile[];
         newDirectories?: Directory[];
         pathInView?: string;
@@ -58,7 +62,7 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
       isUploading.value = Boolean(state.kindsInProgress?.includes(uploadKind));
       uploadProgress.value = state.kind === uploadKind ? (state.uploadProgress || '') : '';
 
-      if (state.error) {
+      if (state.error && state.kind === uploadKind) {
         console.error(new Error(state.error));
         uploadError.value = state.error;
       }
@@ -179,7 +183,7 @@ export function useUploadQueue({ isEnabled, path, files, directories, uploadSess
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
         sessionTag: uploadSessionTag,
-        items: items.map((item) => ({ ...item, pathInView })),
+        items: items.map((item) => ({ ...item, pathInView, kind: uploadKind })),
       });
 
       return;

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -19,12 +19,12 @@ interface UseUploadQueueOptions {
   files: Signal<DirectoryFile[]>;
   directories: Signal<Directory[]>;
   uploadSessionTag?: string;
-  uploadKind?: 'upload' | 'note';
+  uploadKind?: 'file' | 'photo' | 'note';
 }
 
 // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
 export function useUploadQueue(
-  { isEnabled, path, files, directories, uploadSessionTag = '', uploadKind = 'upload' }: UseUploadQueueOptions,
+  { isEnabled, path, files, directories, uploadSessionTag = '', uploadKind = 'file' }: UseUploadQueueOptions,
 ) {
   const isUploading = useSignal<boolean>(false);
   const uploadProgress = useSignal<string>('');

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -23,6 +23,31 @@ interface UseUploadQueueOptions {
   uploadKind?: 'file' | 'photo' | 'note';
 }
 
+// Messages go to the registration's active worker instead of `navigator.serviceWorker.controller`, because a freshly-installed worker is already active while `controller` is still null until its `clients.claim()` lands, which would silently skip the service worker for the first upload after a hard load.
+export async function postToUploadServiceWorker(message: Record<string, unknown>): Promise<boolean> {
+  if (!('serviceWorker' in navigator)) {
+    return false;
+  }
+
+  try {
+    const registration = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<undefined>((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+
+    if (!registration?.active) {
+      return false;
+    }
+
+    registration.active.postMessage(message);
+
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
 // Uploads run inside a service worker (public/sw.js) so they survive a page refresh. This tab just enqueues files and listens for progress here; on mount it also queries whether a job is already running (e.g. right after a refresh) to hydrate the UI from it.
 export function useUploadQueue(
   { isEnabled, path, files, directories, uploadSessionTag = '', uploadKind = 'file' }: UseUploadQueueOptions,
@@ -78,16 +103,7 @@ export function useUploadQueue(
       }
     };
 
-    async function queryUploadState() {
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        registration.active?.postMessage({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });
-      } catch (error) {
-        console.error(error);
-      }
-    }
-
-    queryUploadState();
+    postToUploadServiceWorker({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });
 
     return () => {
       uploadChannel.close();
@@ -225,15 +241,13 @@ export function useUploadQueue(
       return;
     }
 
-    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
+    const wasEnqueuedInServiceWorker = isEnabled && await postToUploadServiceWorker({
+      type: 'ENQUEUE_UPLOAD',
+      sessionTag: uploadSessionTag,
+      items: itemsToUpload.map((item) => ({ ...item, pathInView, kind: uploadKind })),
+    });
 
-    if (serviceWorker) {
-      serviceWorker.postMessage({
-        type: 'ENQUEUE_UPLOAD',
-        sessionTag: uploadSessionTag,
-        items: itemsToUpload.map((item) => ({ ...item, pathInView, kind: uploadKind })),
-      });
-
+    if (wasEnqueuedInServiceWorker) {
       return;
     }
 

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'preact/hooks';
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
 import { ResponseBody as ChunkUploadResponseBody } from '/pages/api/files/upload-chunk.ts';
+import { RequestBody as GetFilesRequestBody, ResponseBody as GetFilesResponseBody } from '/pages/api/files/get.ts';
 
 // 10 MB chunks keep each request faster.
 const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
@@ -165,17 +166,59 @@ export function useUploadQueue(
     }
   }
 
-  function enqueueUpload(items: UploadQueueItem[]) {
+  // A directory's existing file names, for skipping upload items that would just hit "already exists".
+  async function findExistingNames(parentPath: string): Promise<Set<string>> {
+    try {
+      const requestBody: GetFilesRequestBody = { parentPath };
+
+      const response = await fetch('/api/files/get', { method: 'POST', body: JSON.stringify(requestBody) });
+
+      if (!response.ok) {
+        return new Set();
+      }
+
+      const result = await response.json() as GetFilesResponseBody;
+
+      return new Set(result.files.map((file) => file.file_name));
+    } catch (error) {
+      console.error(error);
+      // Fail open: an upload that turns out to clash still gets caught (just later, by the server) instead of being blocked by this check itself failing.
+      return new Set();
+    }
+  }
+
+  async function enqueueUpload(items: UploadQueueItem[]) {
     if (items.length === 0) {
+      return;
+    }
+
+    isUploading.value = true;
+    uploadProgress.value = '';
+    uploadError.value = '';
+
+    const uniqueParentPaths = [...new Set(items.map((item) => item.parentPath))];
+    const existingNamesByParentPath = new Map(
+      await Promise.all(
+        uniqueParentPaths.map(async (parentPath) => [parentPath, await findExistingNames(parentPath)] as const),
+      ),
+    );
+
+    const itemsToUpload = items.filter((item) => {
+      if (existingNamesByParentPath.get(item.parentPath)?.has(item.file.name)) {
+        uploadError.value = `${item.file.name}: A file with this name already exists.`;
+        return false;
+      }
+
+      return true;
+    });
+
+    if (itemsToUpload.length === 0) {
+      isUploading.value = false;
       return;
     }
 
     // Capture once: the user may navigate away during a long upload, which would change path.value and cause the final response to refresh the wrong directory listing.
     const pathInView = path.value;
-
-    isUploading.value = true;
-    uploadProgress.value = '';
-    uploadError.value = '';
 
     const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
 
@@ -183,29 +226,27 @@ export function useUploadQueue(
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
         sessionTag: uploadSessionTag,
-        items: items.map((item) => ({ ...item, pathInView, kind: uploadKind })),
+        items: itemsToUpload.map((item) => ({ ...item, pathInView, kind: uploadKind })),
       });
 
       return;
     }
 
     // Fallback for browsers/contexts without an active service worker: upload directly, as before.
-    (async () => {
-      for (const item of items) {
-        try {
-          if (item.file.size >= CHUNK_SIZE_BYTES) {
-            await uploadFileChunked(item.file, item.parentPath, pathInView);
-          } else {
-            await uploadFileSingle(item.file, item.parentPath, pathInView);
-          }
-        } catch (error) {
-          console.error(error);
-          uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
+    for (const item of itemsToUpload) {
+      try {
+        if (item.file.size >= CHUNK_SIZE_BYTES) {
+          await uploadFileChunked(item.file, item.parentPath, pathInView);
+        } else {
+          await uploadFileSingle(item.file, item.parentPath, pathInView);
         }
+      } catch (error) {
+        console.error(error);
+        uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
       }
+    }
 
-      isUploading.value = false;
-    })();
+    isUploading.value = false;
   }
 
   return { isUploading, uploadProgress, uploadError, enqueueUpload };

--- a/components/notes/CreateNoteModal.tsx
+++ b/components/notes/CreateNoteModal.tsx
@@ -2,7 +2,7 @@ import { useSignal } from '@preact/signals';
 
 interface CreateNoteModalProps {
   isOpen: boolean;
-  onClickSave: (newNoteName: string) => Promise<void>;
+  onClickSave: (newNoteName: string) => void;
   onClose: () => void;
 }
 

--- a/components/notes/MainNotes.tsx
+++ b/components/notes/MainNotes.tsx
@@ -20,9 +20,10 @@ interface MainNotesProps {
   initialDirectories: Directory[];
   initialFiles: DirectoryFile[];
   initialPath: string;
+  uploadSessionTag?: string;
 }
 
-export default function MainNotes({ initialDirectories, initialFiles, initialPath }: MainNotesProps) {
+export default function MainNotes({ initialDirectories, initialFiles, initialPath, uploadSessionTag }: MainNotesProps) {
   const isAdding = useSignal<boolean>(false);
   const isDeleting = useSignal<boolean>(false);
   const directories = useSignal<Directory[]>(initialDirectories);
@@ -32,11 +33,12 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
   const isNewNoteModalOpen = useSignal<boolean>(false);
   const isNewDirectoryModalOpen = useSignal<boolean>(false);
 
-  const { isUploading: isCreatingNote, enqueueUpload } = useUploadQueue({
+  const { isUploading: isCreatingNote, uploadError: createNoteError, enqueueUpload } = useUploadQueue({
     isEnabled: true,
     path,
     files,
     directories,
+    uploadSessionTag,
   });
 
   function onClickCreateNote() {
@@ -287,6 +289,14 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
             : null}
           {!isDeleting.value && !isAdding.value && !isCreatingNote.value ? <>&nbsp;</> : null}
         </span>
+
+        {createNoteError.value
+          ? (
+            <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
+              Creating the note failed — {createNoteError.value}
+            </span>
+          )
+          : null}
       </section>
 
       <CreateDirectoryModal

--- a/components/notes/MainNotes.tsx
+++ b/components/notes/MainNotes.tsx
@@ -1,7 +1,6 @@
 import { useSignal } from '@preact/signals';
 
 import { Directory, DirectoryFile } from '/lib/types.ts';
-import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
 import { RequestBody as DeleteRequestBody, ResponseBody as DeleteResponseBody } from '/pages/api/files/delete.ts';
 import {
   RequestBody as CreateDirectoryRequestBody,
@@ -11,6 +10,7 @@ import {
   RequestBody as DeleteDirectoryRequestBody,
   ResponseBody as DeleteDirectoryResponseBody,
 } from '/pages/api/files/delete-directory.ts';
+import { useUploadQueue } from '/components/files/useUploadQueue.ts';
 import ListFiles from '/components/files/ListFiles.tsx';
 import FilesBreadcrumb from '/components/files/FilesBreadcrumb.tsx';
 import CreateDirectoryModal from '/components/files/CreateDirectoryModal.tsx';
@@ -32,6 +32,13 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
   const isNewNoteModalOpen = useSignal<boolean>(false);
   const isNewDirectoryModalOpen = useSignal<boolean>(false);
 
+  const { isUploading: isCreatingNote, enqueueUpload } = useUploadQueue({
+    isEnabled: true,
+    path,
+    files,
+    directories,
+  });
+
   function onClickCreateNote() {
     if (isNewNoteModalOpen.value) {
       isNewNoteModalOpen.value = false;
@@ -41,48 +48,21 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
     isNewNoteModalOpen.value = true;
   }
 
-  async function onClickSaveNote(newNoteName: string) {
-    if (isAdding.value) {
-      return;
-    }
-
+  function onClickSaveNote(newNoteName: string) {
     if (!newNoteName) {
       return;
     }
 
     areNewOptionsOption.value = false;
-    isAdding.value = true;
+    isNewNoteModalOpen.value = false;
 
-    const requestBody = new FormData();
-    requestBody.set('parent_path', path.value);
-    requestBody.set('path_in_view', path.value);
-    requestBody.set('name', `${newNoteName}.md`);
-    requestBody.set('contents', `# ${newNoteName}\n\nStart your new note!\n`);
+    const noteFile = new File(
+      [`# ${newNoteName}\n\nStart your new note!\n`],
+      `${newNoteName}.md`,
+      { type: 'text/markdown' },
+    );
 
-    try {
-      const response = await fetch(`/api/files/upload`, {
-        method: 'POST',
-        body: requestBody,
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to create note. ${response.statusText} ${await response.text()}`);
-      }
-
-      const result = await response.json() as UploadResponseBody;
-
-      if (!result.success) {
-        throw new Error('Failed to create note!');
-      }
-
-      files.value = [...result.newFiles];
-
-      isNewNoteModalOpen.value = false;
-    } catch (error) {
-      console.error(error);
-    }
-
-    isAdding.value = false;
+    enqueueUpload([{ file: noteFile, parentPath: path.value }]);
   }
 
   function onCloseCreateNote() {
@@ -242,7 +222,7 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
                 <img
                   src='/public/images/add.svg'
                   alt='Add new note or directory'
-                  class={`white ${isAdding.value ? 'animate-spin' : ''}`}
+                  class={`white ${isAdding.value || isCreatingNote.value ? 'animate-spin' : ''}`}
                   width={20}
                   height={20}
                 />
@@ -298,14 +278,14 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
               </>
             )
             : null}
-          {isAdding.value
+          {isAdding.value || isCreatingNote.value
             ? (
               <>
                 <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />Creating...
               </>
             )
             : null}
-          {!isDeleting.value && !isAdding.value ? <>&nbsp;</> : null}
+          {!isDeleting.value && !isAdding.value && !isCreatingNote.value ? <>&nbsp;</> : null}
         </span>
       </section>
 

--- a/components/notes/MainNotes.tsx
+++ b/components/notes/MainNotes.tsx
@@ -39,6 +39,7 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
     files,
     directories,
     uploadSessionTag,
+    uploadKind: 'note',
   });
 
   function onClickCreateNote() {

--- a/components/notes/MainNotes.tsx
+++ b/components/notes/MainNotes.tsx
@@ -10,7 +10,7 @@ import {
   RequestBody as DeleteDirectoryRequestBody,
   ResponseBody as DeleteDirectoryResponseBody,
 } from '/pages/api/files/delete-directory.ts';
-import { useUploadQueue } from '/components/files/useUploadQueue.ts';
+import { postToUploadServiceWorker, useUploadQueue } from '/components/files/useUploadQueue.ts';
 import ListFiles from '/components/files/ListFiles.tsx';
 import FilesBreadcrumb from '/components/files/FilesBreadcrumb.tsx';
 import CreateDirectoryModal from '/components/files/CreateDirectoryModal.tsx';
@@ -160,6 +160,12 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
         }
 
         directories.value = [...result.newDirectories];
+
+        await postToUploadServiceWorker({
+          type: 'DIRECTORY_DELETED',
+          sessionTag: uploadSessionTag ?? '',
+          path: `${parentPath}${name}/`,
+        });
       } catch (error) {
         console.error(error);
       }

--- a/components/photos/MainPhotos.tsx
+++ b/components/photos/MainPhotos.tsx
@@ -15,9 +15,12 @@ interface MainPhotosProps {
   initialDirectories: Directory[];
   initialFiles: DirectoryFile[];
   initialPath: string;
+  uploadSessionTag?: string;
 }
 
-export default function MainPhotos({ initialDirectories, initialFiles, initialPath }: MainPhotosProps) {
+export default function MainPhotos(
+  { initialDirectories, initialFiles, initialPath, uploadSessionTag }: MainPhotosProps,
+) {
   const isAdding = useSignal<boolean>(false);
   const directories = useSignal<Directory[]>(initialDirectories);
   const files = useSignal<DirectoryFile[]>(initialFiles);
@@ -25,11 +28,12 @@ export default function MainPhotos({ initialDirectories, initialFiles, initialPa
   const areNewOptionsOption = useSignal<boolean>(false);
   const isNewDirectoryModalOpen = useSignal<boolean>(false);
 
-  const { isUploading, uploadProgress, enqueueUpload } = useUploadQueue({
+  const { isUploading, uploadProgress, uploadError, enqueueUpload } = useUploadQueue({
     isEnabled: true,
     path,
     files,
     directories,
+    uploadSessionTag,
   });
 
   function onClickUploadFile() {
@@ -201,6 +205,14 @@ export default function MainPhotos({ initialDirectories, initialFiles, initialPa
             : null}
           {!isAdding.value && !isUploading.value ? <>&nbsp;</> : null}
         </span>
+
+        {uploadError.value
+          ? (
+            <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
+              Upload failed — {uploadError.value}
+            </span>
+          )
+          : null}
       </section>
 
       <CreateDirectoryModal

--- a/components/photos/MainPhotos.tsx
+++ b/components/photos/MainPhotos.tsx
@@ -1,11 +1,11 @@
 import { useSignal } from '@preact/signals';
 
 import { Directory, DirectoryFile } from '/lib/types.ts';
-import { ResponseBody as UploadResponseBody } from '/pages/api/files/upload.ts';
 import {
   RequestBody as CreateDirectoryRequestBody,
   ResponseBody as CreateDirectoryResponseBody,
 } from '/pages/api/files/create-directory.ts';
+import { useUploadQueue } from '/components/files/useUploadQueue.ts';
 import CreateDirectoryModal from '/components/files/CreateDirectoryModal.tsx';
 import ListFiles from '/components/files/ListFiles.tsx';
 import FilesBreadcrumb from '/components/files/FilesBreadcrumb.tsx';
@@ -19,12 +19,18 @@ interface MainPhotosProps {
 
 export default function MainPhotos({ initialDirectories, initialFiles, initialPath }: MainPhotosProps) {
   const isAdding = useSignal<boolean>(false);
-  const isUploading = useSignal<boolean>(false);
   const directories = useSignal<Directory[]>(initialDirectories);
   const files = useSignal<DirectoryFile[]>(initialFiles);
   const path = useSignal<string>(initialPath);
   const areNewOptionsOption = useSignal<boolean>(false);
   const isNewDirectoryModalOpen = useSignal<boolean>(false);
+
+  const { isUploading, uploadProgress, enqueueUpload } = useUploadQueue({
+    isEnabled: true,
+    path,
+    files,
+    directories,
+  });
 
   function onClickUploadFile() {
     const fileInput = document.createElement('input');
@@ -33,49 +39,18 @@ export default function MainPhotos({ initialDirectories, initialFiles, initialPa
     fileInput.accept = 'image/*,video/*';
     fileInput.click();
 
-    fileInput.onchange = async (event) => {
+    fileInput.onchange = (event) => {
       const chosenFilesList = (event.target as HTMLInputElement)?.files!;
 
-      const chosenFiles = Array.from(chosenFilesList);
+      const chosenFiles = Array.from(chosenFilesList).filter(Boolean);
 
-      isUploading.value = true;
-
-      for (const chosenFile of chosenFiles) {
-        if (!chosenFile) {
-          continue;
-        }
-
-        areNewOptionsOption.value = false;
-
-        const requestBody = new FormData();
-        requestBody.set('parent_path', path.value);
-        requestBody.set('path_in_view', path.value);
-        requestBody.set('name', chosenFile.name);
-        requestBody.set('contents', chosenFile);
-
-        try {
-          const response = await fetch(`/api/files/upload`, {
-            method: 'POST',
-            body: requestBody,
-          });
-
-          if (!response.ok) {
-            throw new Error(`Failed to upload photo. ${response.statusText} ${await response.text()}`);
-          }
-
-          const result = await response.json() as UploadResponseBody;
-
-          if (!result.success) {
-            throw new Error('Failed to upload photo!');
-          }
-
-          files.value = [...result.newFiles];
-        } catch (error) {
-          console.error(error);
-        }
+      if (chosenFiles.length === 0) {
+        return;
       }
 
-      isUploading.value = false;
+      areNewOptionsOption.value = false;
+
+      enqueueUpload(chosenFiles.map((chosenFile) => ({ file: chosenFile, parentPath: path.value })));
     };
   }
 
@@ -219,7 +194,8 @@ export default function MainPhotos({ initialDirectories, initialFiles, initialPa
           {isUploading.value
             ? (
               <>
-                <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />Uploading...
+                <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />
+                {uploadProgress.value || 'Uploading...'}
               </>
             )
             : null}

--- a/components/photos/MainPhotos.tsx
+++ b/components/photos/MainPhotos.tsx
@@ -34,6 +34,7 @@ export default function MainPhotos(
     files,
     directories,
     uploadSessionTag,
+    uploadKind: 'photo',
   });
 
   function onClickUploadFile() {

--- a/deno.lock
+++ b/deno.lock
@@ -32,6 +32,7 @@
     "jsr:@std/fs@1.0.24": "1.0.24",
     "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/html@^1.0.7": "1.0.7",
+    "jsr:@std/http@*": "1.1.2",
     "jsr:@std/http@1.1.2": "1.1.2",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -150,6 +150,15 @@ async function getDataFromCookie(
   return null;
 }
 
+// The upload service worker's queue outlives the page that created it, so every queued request is tagged with the session that enqueued it, and the upload endpoints refuse tags that don't match the cookie they're now being sent with. It's a hash so a page never exposes the raw session id to its own JS.
+export async function generateUploadSessionTag(sessionId?: string): Promise<string> {
+  if (!sessionId) {
+    return '';
+  }
+
+  return await generateHash(`${sessionId}:${PASSWORD_SALT}`, 'SHA-256');
+}
+
 export async function generateToken<T = JwtData>(tokenData: T): Promise<string> {
   const key = await generateKey(JWT_SECRET);
 

--- a/lib/auth_test.ts
+++ b/lib/auth_test.ts
@@ -1,0 +1,19 @@
+import { assertEquals, assertNotEquals } from '@std/assert';
+
+import { generateUploadSessionTag } from './auth.ts';
+
+Deno.test('that generateUploadSessionTag works', async () => {
+  const tag = await generateUploadSessionTag('cf8b3a5e-0e6e-4a9a-9a1e-1f4c0d8b1a11');
+
+  assertEquals(tag, await generateUploadSessionTag('cf8b3a5e-0e6e-4a9a-9a1e-1f4c0d8b1a11'));
+
+  // A queue tagged by another session must not match, otherwise leftover uploads would be accepted under the session that's logged in now
+  assertNotEquals(tag, await generateUploadSessionTag('0b2d4f6a-1c3e-4b5d-8e7f-2a9c0b1d3e42'));
+
+  // The raw session id never leaves the server
+  assertNotEquals(tag, 'cf8b3a5e-0e6e-4a9a-9a1e-1f4c0d8b1a11');
+
+  // Requests without a session (WebDAV/basic auth) get an empty tag, which the upload endpoints skip checking
+  assertEquals(await generateUploadSessionTag(), '');
+  assertEquals(await generateUploadSessionTag(''), '');
+});

--- a/lib/models/files.ts
+++ b/lib/models/files.ts
@@ -215,7 +215,7 @@ export class FileModel {
     path: string,
     name: string,
     contents: string | ArrayBuffer,
-  ): Promise<boolean> {
+  ): Promise<{ success: boolean; alreadyExists?: boolean }> {
     await ensureUserPathIsValidAndSecurelyAccessible(userId, join(path, name));
 
     const rootPath = join(await AppConfig.getFilesRootPath(), userId, path);
@@ -237,10 +237,10 @@ export class FileModel {
       }
     } catch (error) {
       console.error(error);
-      return false;
+      return { success: false, alreadyExists: error instanceof Deno.errors.AlreadyExists };
     }
 
-    return true;
+    return { success: true };
   }
 
   static async update(

--- a/lib/utils/layout.tsx
+++ b/lib/utils/layout.tsx
@@ -81,7 +81,7 @@ export async function basicLayoutResponse(htmlContent: string, options: BasicLay
   const headers: HeadersInit = {
     'content-type': 'text/html; charset=utf-8',
     'content-security-policy':
-      `default-src 'self'; child-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'`,
+      `default-src 'self'; child-src 'none'; worker-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'`,
     'x-frame-options': 'DENY',
     'x-content-type-options': 'nosniff',
     'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',

--- a/lib/utils/layout.tsx
+++ b/lib/utils/layout.tsx
@@ -57,6 +57,13 @@ async function basicLayout(
 
       <body class="h-full">
         ${headerHtml} ${htmlContent}
+
+        <script>
+          // Tell the upload service worker to abort its queue before navigating away, instead of letting it keep running against a session that's about to be gone.
+          document.getElementById('logout-link')?.addEventListener('click', () => {
+            navigator.serviceWorker?.controller?.postMessage({ type: 'ABORT_UPLOADS' });
+          });
+        </script>
       </body>
     </html>
   `;

--- a/main.ts
+++ b/main.ts
@@ -24,7 +24,7 @@ function applyCorsHeadersToResponse(origin: string, response: Response) {
   if (!headers.get('content-security-policy')) {
     headers.set(
       'Content-Security-Policy',
-      "default-src 'self'; child-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'",
+      "default-src 'self'; child-src 'none'; worker-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'",
     );
   }
   if (!headers.get('x-frame-options')) {

--- a/pages/api/files/upload-abort.ts
+++ b/pages/api/files/upload-abort.ts
@@ -1,0 +1,44 @@
+import { join } from '@std/path';
+
+import page, { RequestHandlerParams } from '/lib/page.ts';
+import { AppConfig } from '/lib/config.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
+
+export interface RequestBody {
+  upload_id: string;
+  upload_session_tag: string;
+}
+
+export interface ResponseBody {
+  success: boolean;
+}
+
+// Called by the upload service worker when it drops a chunked upload before it finished (e.g. its destination directory got deleted), so the chunks already received don't just sit in .chunk-uploads until the 24h stale sweep.
+async function post({ request, user, session }: RequestHandlerParams) {
+  const requestBody = await request.clone().json() as RequestBody;
+
+  const uploadId = requestBody.upload_id;
+  const uploadSessionTag = requestBody.upload_session_tag;
+
+  if (uploadSessionTag && uploadSessionTag !== await generateUploadSessionTag(session?.tokenData?.session_id)) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  if (!uploadId || !/^[a-zA-Z0-9-]+$/.test(uploadId)) {
+    return new Response('Bad Request', { status: 400 });
+  }
+
+  const filesRootPath = await AppConfig.getFilesRootPath();
+  const uploadDir = join(filesRootPath, user!.id, '.chunk-uploads', uploadId);
+
+  await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
+
+  const responseBody: ResponseBody = { success: true };
+
+  return new Response(JSON.stringify(responseBody));
+}
+
+export default page({
+  post,
+  accessMode: 'user',
+});

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -9,6 +9,7 @@ import { generateUploadSessionTag } from '/lib/auth.ts';
 export interface ResponseBody {
   success: boolean;
   isComplete: boolean;
+  error?: string;
   newFiles?: DirectoryFile[];
   newDirectories?: Directory[];
 }
@@ -137,7 +138,11 @@ async function post({ request, user, session }: RequestHandlerParams) {
 
       console.error(error);
 
-      const responseBody: ResponseBody = { success: false, isComplete: true };
+      const responseBody: ResponseBody = {
+        success: false,
+        isComplete: true,
+        error: error instanceof Deno.errors.AlreadyExists ? 'A file with this name already exists.' : undefined,
+      };
 
       return new Response(JSON.stringify(responseBody));
     }

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -4,6 +4,7 @@ import page, { RequestHandlerParams } from '/lib/page.ts';
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { DirectoryModel, ensureUserPathIsValidAndSecurelyAccessible, FileModel } from '/lib/models/files.ts';
 import { AppConfig } from '/lib/config.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
 
 export interface ResponseBody {
   success: boolean;
@@ -41,7 +42,7 @@ async function cleanStaleUploads(userUploadDir: string): Promise<void> {
   }
 }
 
-async function post({ request, user }: RequestHandlerParams) {
+async function post({ request, user, session }: RequestHandlerParams) {
   if (
     !(await AppConfig.isAppEnabled('files')) && !(await AppConfig.isAppEnabled('photos')) &&
     !(await AppConfig.isAppEnabled('notes'))
@@ -58,9 +59,15 @@ async function post({ request, user }: RequestHandlerParams) {
   const parentPath = requestBody.get('parent_path') as string;
   const name = requestBody.get('name') as string;
   const chunk = requestBody.get('chunk') as File | null;
+  const uploadSessionTag = requestBody.get('upload_session_tag') as string;
 
   const chunkIndex = parseInt(chunkIndexStr, 10);
   const totalChunks = parseInt(totalChunksStr, 10);
+
+  // Uploads are queued in a service worker that outlives the page, so a queue left over from a previous session must not keep writing into whoever is logged in now. Untagged requests (WebDAV/basic auth) are left alone.
+  if (uploadSessionTag && uploadSessionTag !== await generateUploadSessionTag(session?.tokenData?.session_id)) {
+    return new Response('Forbidden', { status: 403 });
+  }
 
   if (
     !uploadId ||

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -101,6 +101,22 @@ async function post({ request, user, session }: RequestHandlerParams) {
   // On the first chunk of a new upload, evict any stale sessions from this user.
   if (chunkIndex === 0) {
     await cleanStaleUploads(userUploadDir);
+
+    const targetFilePath = join(filesRootPath, user!.id, parentPath, name.trim());
+
+    try {
+      await Deno.stat(targetFilePath);
+
+      const responseBody: ResponseBody = {
+        success: false,
+        isComplete: true,
+        error: 'A file with this name already exists.',
+      };
+
+      return new Response(JSON.stringify(responseBody));
+    } catch {
+      // Doesn't exist yet, proceed with the upload.
+    }
   }
 
   try {

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -48,7 +48,7 @@ async function post({ request, user, session }: RequestHandlerParams) {
     !(await AppConfig.isAppEnabled('files')) && !(await AppConfig.isAppEnabled('photos')) &&
     !(await AppConfig.isAppEnabled('notes'))
   ) {
-    return new Response('Forbidden', { status: 403 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const requestBody = await request.clone().formData();

--- a/pages/api/files/upload-chunk.ts
+++ b/pages/api/files/upload-chunk.ts
@@ -150,7 +150,6 @@ async function post({ request, user, session }: RequestHandlerParams) {
       finalFile = await Deno.open(finalFilePath, { write: true, createNew: true });
     } catch (error) {
       await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
-      await Deno.remove(userUploadDir, { recursive: true }).catch(() => {});
 
       console.error(error);
 
@@ -174,14 +173,12 @@ async function post({ request, user, session }: RequestHandlerParams) {
 
       await Deno.remove(finalFilePath).catch(() => {});
       await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
-      await Deno.remove(userUploadDir, { recursive: true }).catch(() => {});
 
       throw error;
     }
 
     finalFile.close();
     await Deno.remove(uploadDir, { recursive: true });
-    await Deno.remove(userUploadDir, { recursive: true }).catch(() => {});
 
     const newFiles = await FileModel.list(user!.id, pathInView);
     const newDirectories = await DirectoryModel.list(user!.id, pathInView);
@@ -192,7 +189,6 @@ async function post({ request, user, session }: RequestHandlerParams) {
   } catch (error) {
     console.error(error);
     await Deno.remove(uploadDir, { recursive: true }).catch(() => {});
-    await Deno.remove(userUploadDir, { recursive: true }).catch(() => {});
 
     return new Response('Internal Server Error', { status: 500 });
   }

--- a/pages/api/files/upload.ts
+++ b/pages/api/files/upload.ts
@@ -3,6 +3,7 @@ import page, { RequestHandlerParams } from '/lib/page.ts';
 import { Directory, DirectoryFile } from '/lib/types.ts';
 import { DirectoryModel, FileModel } from '/lib/models/files.ts';
 import { AppConfig } from '/lib/config.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
 
 export interface ResponseBody {
   success: boolean;
@@ -10,7 +11,7 @@ export interface ResponseBody {
   newDirectories: Directory[];
 }
 
-async function post({ request, user }: RequestHandlerParams) {
+async function post({ request, user, session }: RequestHandlerParams) {
   if (
     !(await AppConfig.isAppEnabled('files')) && !(await AppConfig.isAppEnabled('photos')) &&
     !(await AppConfig.isAppEnabled('notes'))
@@ -24,6 +25,12 @@ async function post({ request, user }: RequestHandlerParams) {
   const parentPath = requestBody.get('parent_path') as string;
   const name = requestBody.get('name') as string;
   const contents = requestBody.get('contents') as File | string;
+  const uploadSessionTag = requestBody.get('upload_session_tag') as string;
+
+  // Uploads are queued in a service worker that outlives the page, so a queue left over from a previous session must not keep writing into whoever is logged in now. Untagged requests (WebDAV/basic auth) are left alone.
+  if (uploadSessionTag && uploadSessionTag !== await generateUploadSessionTag(session?.tokenData?.session_id)) {
+    return new Response('Forbidden', { status: 403 });
+  }
 
   if (
     !parentPath || !pathInView || !name.trim() || !contents || !parentPath.startsWith('/') ||

--- a/pages/api/files/upload.ts
+++ b/pages/api/files/upload.ts
@@ -7,6 +7,7 @@ import { generateUploadSessionTag } from '/lib/auth.ts';
 
 export interface ResponseBody {
   success: boolean;
+  error?: string;
   newFiles: DirectoryFile[];
   newDirectories: Directory[];
 }
@@ -46,7 +47,12 @@ async function post({ request, user, session }: RequestHandlerParams) {
   const newFiles = await FileModel.list(user!.id, pathInView);
   const newDirectories = await DirectoryModel.list(user!.id, pathInView);
 
-  const responseBody: ResponseBody = { success: createdFile, newFiles, newDirectories };
+  const responseBody: ResponseBody = {
+    success: createdFile.success,
+    error: createdFile.alreadyExists ? 'A file with this name already exists.' : undefined,
+    newFiles,
+    newDirectories,
+  };
 
   return new Response(JSON.stringify(responseBody));
 }

--- a/pages/api/files/upload.ts
+++ b/pages/api/files/upload.ts
@@ -17,7 +17,7 @@ async function post({ request, user, session }: RequestHandlerParams) {
     !(await AppConfig.isAppEnabled('files')) && !(await AppConfig.isAppEnabled('photos')) &&
     !(await AppConfig.isAppEnabled('notes'))
   ) {
-    return new Response('Forbidden', { status: 403 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const requestBody = await request.clone().formData();

--- a/pages/files.ts
+++ b/pages/files.ts
@@ -7,6 +7,7 @@ import { html } from '/public/ts/utils/misc.ts';
 import { basicLayoutResponse } from '/lib/utils/layout.tsx';
 import Loading from '/components/Loading.ts';
 import { SortColumn, sortDirectories, sortFiles, SortOrder } from '/public/ts/utils/files.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
 
 async function get({ request, user, match, session, isRunningLocally }: RequestHandlerParams) {
   const baseUrl = (await AppConfig.getConfig()).auth.baseUrl;
@@ -70,6 +71,7 @@ async function get({ request, user, match, session, isRunningLocally }: RequestH
     areDirectoryDownloadsAllowed,
     initialSortBy,
     initialSortOrder,
+    uploadSessionTag: await generateUploadSessionTag(session?.tokenData?.session_id),
   });
 
   return basicLayoutResponse(htmlContent, {
@@ -93,6 +95,7 @@ function defaultHtmlContent(
     areDirectoryDownloadsAllowed,
     initialSortBy,
     initialSortOrder,
+    uploadSessionTag,
   }: {
     userDirectories: Directory[];
     userFiles: DirectoryFile[];
@@ -102,6 +105,7 @@ function defaultHtmlContent(
     areDirectoryDownloadsAllowed: boolean;
     initialSortBy: string;
     initialSortOrder: string;
+    uploadSessionTag: string;
   },
 ) {
   return html`
@@ -133,6 +137,7 @@ function defaultHtmlContent(
         areDirectoryDownloadsAllowed: ${JSON.stringify(areDirectoryDownloadsAllowed)},
         initialSortBy: ${JSON.stringify(initialSortBy)},
         initialSortOrder: ${JSON.stringify(initialSortOrder)},
+        uploadSessionTag: ${JSON.stringify(uploadSessionTag)},
       });
 
       render(mainFilesApp, mainFilesElement);

--- a/pages/files.ts
+++ b/pages/files.ts
@@ -119,6 +119,7 @@ function defaultHtmlContent(
     window.Fragment = Fragment;
 
     import MainFiles from '/public/components/files/MainFiles.js';
+    import { registerUploadServiceWorker } from '/public/ts/service-worker.ts';
 
     const mainFilesElement = document.getElementById('main-files');
 
@@ -139,15 +140,7 @@ function defaultHtmlContent(
       document.getElementById('loading')?.remove();
     }
 
-    if ('serviceWorker' in navigator) {
-      (async () => {
-        try {
-          await navigator.serviceWorker.register('/public/sw.js', { scope: '/' });
-        } catch (error) {
-          console.error(error);
-        }
-      })();
-    }
+    registerUploadServiceWorker();
     </script>
   `;
 }

--- a/pages/files.ts
+++ b/pages/files.ts
@@ -138,6 +138,16 @@ function defaultHtmlContent(
 
       document.getElementById('loading')?.remove();
     }
+
+    if ('serviceWorker' in navigator) {
+      (async () => {
+        try {
+          await navigator.serviceWorker.register('/public/sw.js', { scope: '/' });
+        } catch (error) {
+          console.error(error);
+        }
+      })();
+    }
     </script>
   `;
 }

--- a/pages/notes.ts
+++ b/pages/notes.ts
@@ -65,6 +65,7 @@ function defaultHtmlContent({ userDirectories, userNotes, currentPath }: {
     window.Fragment = Fragment;
 
     import MainNotes from '/public/components/notes/MainNotes.js';
+    import { registerUploadServiceWorker } from '/public/ts/service-worker.ts';
 
     const mainNotesElement = document.getElementById('main-notes');
 
@@ -79,6 +80,8 @@ function defaultHtmlContent({ userDirectories, userNotes, currentPath }: {
 
       document.getElementById('loading')?.remove();
     }
+
+    registerUploadServiceWorker();
     </script>
   `;
 

--- a/pages/notes.ts
+++ b/pages/notes.ts
@@ -6,6 +6,7 @@ import { DirectoryModel, FileModel } from '/lib/models/files.ts';
 import { basicLayoutResponse } from '/lib/utils/layout.tsx';
 import { html } from '/public/ts/utils/misc.ts';
 import Loading from '/components/Loading.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
 
 async function get({ request, user, match, session, isRunningLocally }: RequestHandlerParams) {
   if (!(await AppConfig.isAppEnabled('notes'))) {
@@ -32,7 +33,12 @@ async function get({ request, user, match, session, isRunningLocally }: RequestH
 
   const userNotes = userFiles.filter((file) => file.file_name.endsWith('.md'));
 
-  const htmlContent = defaultHtmlContent({ userDirectories, userNotes, currentPath });
+  const htmlContent = defaultHtmlContent({
+    userDirectories,
+    userNotes,
+    currentPath,
+    uploadSessionTag: await generateUploadSessionTag(session?.tokenData?.session_id),
+  });
 
   return basicLayoutResponse(htmlContent, {
     currentPath: match.pathname.input,
@@ -45,10 +51,11 @@ async function get({ request, user, match, session, isRunningLocally }: RequestH
   });
 }
 
-function defaultHtmlContent({ userDirectories, userNotes, currentPath }: {
+function defaultHtmlContent({ userDirectories, userNotes, currentPath, uploadSessionTag }: {
   userDirectories: Directory[];
   userNotes: DirectoryFile[];
   currentPath: string;
+  uploadSessionTag: string;
 }) {
   const htmlContent = html`
     <main id="main">
@@ -74,6 +81,7 @@ function defaultHtmlContent({ userDirectories, userNotes, currentPath }: {
         initialDirectories: ${JSON.stringify(userDirectories || [])},
         initialFiles: ${JSON.stringify(userNotes || [])},
         initialPath: ${JSON.stringify(currentPath)},
+        uploadSessionTag: ${JSON.stringify(uploadSessionTag)},
       });
 
       render(mainNotesApp, mainNotesElement);

--- a/pages/photos.ts
+++ b/pages/photos.ts
@@ -70,6 +70,7 @@ function defaultHtmlContent({ userDirectories, userPhotos, currentPath }: {
     window.Fragment = Fragment;
 
     import MainPhotos from '/public/components/photos/MainPhotos.js';
+    import { registerUploadServiceWorker } from '/public/ts/service-worker.ts';
 
     const mainPhotosElement = document.getElementById('main-photos');
 
@@ -84,6 +85,8 @@ function defaultHtmlContent({ userDirectories, userPhotos, currentPath }: {
 
       document.getElementById('loading')?.remove();
     }
+
+    registerUploadServiceWorker();
     </script>
   `;
 }

--- a/pages/photos.ts
+++ b/pages/photos.ts
@@ -7,6 +7,7 @@ import { PHOTO_EXTENSIONS } from '/public/ts/utils/photos.ts';
 import { basicLayoutResponse } from '/lib/utils/layout.tsx';
 import { html } from '/public/ts/utils/misc.ts';
 import Loading from '/components/Loading.ts';
+import { generateUploadSessionTag } from '/lib/auth.ts';
 
 async function get({ request, user, match, session, isRunningLocally }: RequestHandlerParams) {
   if (!(await AppConfig.isAppEnabled('photos'))) {
@@ -37,7 +38,12 @@ async function get({ request, user, match, session, isRunningLocally }: RequestH
     return PHOTO_EXTENSIONS.some((extension) => lowercaseFileName.endsWith(extension));
   });
 
-  const htmlContent = defaultHtmlContent({ userDirectories, userPhotos, currentPath });
+  const htmlContent = defaultHtmlContent({
+    userDirectories,
+    userPhotos,
+    currentPath,
+    uploadSessionTag: await generateUploadSessionTag(session?.tokenData?.session_id),
+  });
 
   return basicLayoutResponse(htmlContent, {
     currentPath: match.pathname.input,
@@ -50,10 +56,11 @@ async function get({ request, user, match, session, isRunningLocally }: RequestH
   });
 }
 
-function defaultHtmlContent({ userDirectories, userPhotos, currentPath }: {
+function defaultHtmlContent({ userDirectories, userPhotos, currentPath, uploadSessionTag }: {
   userDirectories: Directory[];
   userPhotos: DirectoryFile[];
   currentPath: string;
+  uploadSessionTag: string;
 }) {
   return html`
     <main id="main">
@@ -79,6 +86,7 @@ function defaultHtmlContent({ userDirectories, userPhotos, currentPath }: {
         initialDirectories: ${JSON.stringify(userDirectories || [])},
         initialFiles: ${JSON.stringify(userPhotos || [])},
         initialPath: ${JSON.stringify(currentPath)},
+        uploadSessionTag: ${JSON.stringify(uploadSessionTag)},
       });
 
       render(mainPhotosApp, mainPhotosElement);

--- a/public/components/Header.js
+++ b/public/components/Header.js
@@ -80,6 +80,7 @@ export default function Header({
       class: "white"
     })), h("a", {
       href: "/logout",
+      id: "logout-link",
       class: defaultClass
     }, h("img", {
       src: "/public/images/logout.svg",

--- a/public/components/Settings.js
+++ b/public/components/Settings.js
@@ -2,7 +2,7 @@ import { generateFieldHtml, getFormDataField } from '/public/ts/utils/form.ts';
 import { convertObjectToFormData, currencyMap, escapeHtml, html } from '/public/ts/utils/misc.ts';
 import { getEnabledMultiFactorAuthMethodsFromUser } from '/public/ts/utils/multi-factor-auth.ts';
 import { getTimeZones } from '/public/ts/utils/calendar.ts';
-import Loading from '/components/Loading.ts';
+import Loading from "/public/components/Loading.js";
 export const actionWords = new Map([['change-email', 'change email'], ['verify-change-email', 'change email'], ['change-password', 'change password'], ['change-dav-password', 'change WebDav password'], ['delete-account', 'delete account'], ['change-currency', 'change currency'], ['change-timezone', 'change timezone']]);
 function formFields(action, formData, currency, timezoneId) {
   const fields = [{

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -43,6 +43,7 @@ export default function MainFiles({
   const {
     isUploading,
     uploadProgress,
+    uploadError,
     enqueueUpload
   } = useUploadQueue({
     isEnabled: !fileShareId,
@@ -668,7 +669,9 @@ export default function MainFiles({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Updating...") : null, !isDeleting.value && !isAdding.value && !isUploading.value && !isUpdating.value ? h(Fragment, null, "\xA0") : null)), !fileShareId ? h("section", {
+  }), "Updating...") : null, !isDeleting.value && !isAdding.value && !isUploading.value && !isUpdating.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
+    class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
+  }, "Upload failed \u2014 ", uploadError.value) : null), !fileShareId ? h("section", {
     class: "flex flex-row items-center justify-start my-12"
   }, h("span", {
     class: "font-semibold"

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -1,5 +1,6 @@
 import { useSignal } from '@preact/signals';
 import { sortDirectories, sortFiles } from '/public/ts/utils/files.ts';
+import { useUploadQueue } from './useUploadQueue.ts';
 import SearchFiles from "./SearchFiles.js";
 import ListFiles from "./ListFiles.js";
 import FilesBreadcrumb from "./FilesBreadcrumb.js";
@@ -20,8 +21,6 @@ export default function MainFiles({
   initialSortOrder = 'asc'
 }) {
   const isAdding = useSignal(false);
-  const isUploading = useSignal(false);
-  const uploadProgress = useSignal('');
   const isDeleting = useSignal(false);
   const isUpdating = useSignal(false);
   const directories = useSignal(initialDirectories);
@@ -40,6 +39,16 @@ export default function MainFiles({
   const moveDirectoryOrFileModal = useSignal(null);
   const createShareModal = useSignal(null);
   const manageShareModal = useSignal(null);
+  const {
+    isUploading,
+    uploadProgress,
+    enqueueUpload
+  } = useUploadQueue({
+    isEnabled: !fileShareId,
+    path,
+    files,
+    directories
+  });
   function onClickSort(column) {
     let newSortOrder = 'asc';
     if (sortBy.value === column) {
@@ -69,61 +78,6 @@ export default function MainFiles({
       }).catch(console.error);
     }
   }
-  const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
-  async function uploadFileSingle(chosenFile, parentPath) {
-    const requestBody = new FormData();
-    requestBody.set('path_in_view', path.value);
-    requestBody.set('parent_path', parentPath);
-    requestBody.set('name', chosenFile.name);
-    requestBody.set('contents', chosenFile);
-    const response = await fetch(`/api/files/upload`, {
-      method: 'POST',
-      body: requestBody
-    });
-    if (!response.ok) {
-      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
-    }
-    const result = await response.json();
-    if (!result.success) {
-      throw new Error('Failed to upload file!');
-    }
-    files.value = [...result.newFiles];
-    directories.value = [...result.newDirectories];
-  }
-  async function uploadFileChunked(chosenFile, parentPath) {
-    const totalChunks = Math.ceil(chosenFile.size / CHUNK_SIZE_BYTES);
-    const uploadId = crypto.randomUUID();
-    const pathInView = path.value;
-    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-      uploadProgress.value = `Uploading ${chosenFile.name} (${chunkIndex + 1}/${totalChunks})…`;
-      const start = chunkIndex * CHUNK_SIZE_BYTES;
-      const end = Math.min(start + CHUNK_SIZE_BYTES, chosenFile.size);
-      const chunkBlob = chosenFile.slice(start, end);
-      const requestBody = new FormData();
-      requestBody.set('upload_id', uploadId);
-      requestBody.set('chunk_index', String(chunkIndex));
-      requestBody.set('total_chunks', String(totalChunks));
-      requestBody.set('path_in_view', pathInView);
-      requestBody.set('parent_path', parentPath);
-      requestBody.set('name', chosenFile.name);
-      requestBody.set('chunk', chunkBlob);
-      const response = await fetch(`/api/files/upload-chunk`, {
-        method: 'POST',
-        body: requestBody
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`);
-      }
-      const result = await response.json();
-      if (!result.success) {
-        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
-      }
-      if (result.isComplete) {
-        files.value = [...result.newFiles];
-        directories.value = [...result.newDirectories];
-      }
-    }
-  }
   function onClickUploadFile(uploadDirectory = false) {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -134,33 +88,24 @@ export default function MainFiles({
       fileInput.directory = true;
     }
     fileInput.click();
-    fileInput.onchange = async event => {
+    fileInput.onchange = event => {
       const chosenFilesList = event.target?.files;
       const chosenFiles = Array.from(chosenFilesList);
-      isUploading.value = true;
-      uploadProgress.value = '';
-      for (const chosenFile of chosenFiles) {
-        if (!chosenFile) {
-          continue;
-        }
-        areNewOptionsOpen.value = false;
-        let fileParentPath = path.value;
-        if (chosenFile.webkitRelativePath) {
-          const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
-          fileParentPath = `${path.value}${directoryPath}`;
-        }
-        uploadProgress.value = '';
-        try {
-          if (chosenFile.size >= CHUNK_SIZE_BYTES) {
-            await uploadFileChunked(chosenFile, fileParentPath);
-          } else {
-            await uploadFileSingle(chosenFile, fileParentPath);
-          }
-        } catch (error) {
-          console.error(error);
-        }
+      if (chosenFiles.length === 0) {
+        return;
       }
-      isUploading.value = false;
+      areNewOptionsOpen.value = false;
+      function getFileParentPath(chosenFile) {
+        if (!chosenFile.webkitRelativePath) {
+          return path.value;
+        }
+        const directoryPath = chosenFile.webkitRelativePath.replace(chosenFile.name, '');
+        return `${path.value}${directoryPath}`;
+      }
+      enqueueUpload(chosenFiles.map(chosenFile => ({
+        file: chosenFile,
+        parentPath: getFileParentPath(chosenFile)
+      })));
     };
   }
   function onClickCreateDirectory() {

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -1,6 +1,6 @@
 import { useSignal } from '@preact/signals';
 import { sortDirectories, sortFiles } from '/public/ts/utils/files.ts';
-import { useUploadQueue } from './useUploadQueue.ts';
+import { useUploadQueue } from "./useUploadQueue.js";
 import SearchFiles from "./SearchFiles.js";
 import ListFiles from "./ListFiles.js";
 import FilesBreadcrumb from "./FilesBreadcrumb.js";
@@ -18,7 +18,8 @@ export default function MainFiles({
   areDirectoryDownloadsAllowed,
   fileShareId,
   initialSortBy = 'name',
-  initialSortOrder = 'asc'
+  initialSortOrder = 'asc',
+  uploadSessionTag
 }) {
   const isAdding = useSignal(false);
   const isDeleting = useSignal(false);
@@ -47,7 +48,8 @@ export default function MainFiles({
     isEnabled: !fileShareId,
     path,
     files,
-    directories
+    directories,
+    uploadSessionTag
   });
   function onClickSort(column) {
     let newSortOrder = 'asc';

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -1,6 +1,6 @@
 import { useSignal } from '@preact/signals';
 import { sortDirectories, sortFiles } from '/public/ts/utils/files.ts';
-import { useUploadQueue } from "./useUploadQueue.js";
+import { postToUploadServiceWorker, useUploadQueue } from "./useUploadQueue.js";
 import SearchFiles from "./SearchFiles.js";
 import ListFiles from "./ListFiles.js";
 import FilesBreadcrumb from "./FilesBreadcrumb.js";
@@ -346,9 +346,9 @@ export default function MainFiles({
           throw new Error('Failed to delete directory!');
         }
         directories.value = [...result.newDirectories];
-        navigator.serviceWorker?.controller?.postMessage({
+        await postToUploadServiceWorker({
           type: 'DIRECTORY_DELETED',
-          sessionTag: uploadSessionTag,
+          sessionTag: uploadSessionTag ?? '',
           path: `${parentPath}${name}/`
         });
       } catch (error) {

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -50,7 +50,8 @@ export default function MainFiles({
     path,
     files,
     directories,
-    uploadSessionTag
+    uploadSessionTag,
+    uploadKind: 'file'
   });
   function onClickSort(column) {
     let newSortOrder = 'asc';

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -346,6 +346,11 @@ export default function MainFiles({
           throw new Error('Failed to delete directory!');
         }
         directories.value = [...result.newDirectories];
+        navigator.serviceWorker?.controller?.postMessage({
+          type: 'DIRECTORY_DELETED',
+          sessionTag: uploadSessionTag,
+          path: `${parentPath}${name}/`
+        });
       } catch (error) {
         console.error(error);
       }

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -10,6 +10,7 @@ export function useUploadQueue({
 }) {
   const isUploading = useSignal(false);
   const uploadProgress = useSignal('');
+  const uploadError = useSignal('');
   useEffect(() => {
     if (!isEnabled || !('serviceWorker' in navigator)) {
       return;
@@ -27,6 +28,7 @@ export function useUploadQueue({
       uploadProgress.value = state.uploadProgress || '';
       if (state.error) {
         console.error(new Error(state.error));
+        uploadError.value = state.error;
       }
       if (state.newFiles && state.pathInView === path.value) {
         files.value = [...state.newFiles];
@@ -67,7 +69,7 @@ export function useUploadQueue({
     }
     const result = await response.json();
     if (!result.success) {
-      throw new Error('Failed to upload file!');
+      throw new Error(result.error || 'Failed to upload file!');
     }
     files.value = [...result.newFiles];
     directories.value = [...result.newDirectories];
@@ -98,7 +100,7 @@ export function useUploadQueue({
       }
       const result = await response.json();
       if (!result.success) {
-        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+        throw new Error(result.error || `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
       }
       if (result.isComplete) {
         files.value = [...result.newFiles];
@@ -113,6 +115,7 @@ export function useUploadQueue({
     const pathInView = path.value;
     isUploading.value = true;
     uploadProgress.value = '';
+    uploadError.value = '';
     const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
     if (serviceWorker) {
       serviceWorker.postMessage({
@@ -135,6 +138,7 @@ export function useUploadQueue({
           }
         } catch (error) {
           console.error(error);
+          uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
         }
       }
       isUploading.value = false;
@@ -143,6 +147,7 @@ export function useUploadQueue({
   return {
     isUploading,
     uploadProgress,
+    uploadError,
     enqueueUpload
   };
 }

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -5,7 +5,8 @@ export function useUploadQueue({
   isEnabled,
   path,
   files,
-  directories
+  directories,
+  uploadSessionTag = ''
 }) {
   const isUploading = useSignal(false);
   const uploadProgress = useSignal('');
@@ -17,6 +18,9 @@ export function useUploadQueue({
     uploadChannel.onmessage = event => {
       const state = event.data;
       if (!state || state.type !== 'STATE') {
+        return;
+      }
+      if (state.sessionTag && state.sessionTag !== uploadSessionTag) {
         return;
       }
       isUploading.value = state.isUploading;
@@ -35,7 +39,8 @@ export function useUploadQueue({
       try {
         const registration = await navigator.serviceWorker.ready;
         registration.active?.postMessage({
-          type: 'QUERY_STATE'
+          type: 'QUERY_STATE',
+          sessionTag: uploadSessionTag
         });
       } catch (error) {
         console.error(error);
@@ -51,6 +56,7 @@ export function useUploadQueue({
     requestBody.set('path_in_view', pathInView);
     requestBody.set('parent_path', parentPath);
     requestBody.set('name', file.name);
+    requestBody.set('upload_session_tag', uploadSessionTag);
     requestBody.set('contents', file);
     const response = await fetch(`/api/files/upload`, {
       method: 'POST',
@@ -81,6 +87,7 @@ export function useUploadQueue({
       requestBody.set('path_in_view', pathInView);
       requestBody.set('parent_path', parentPath);
       requestBody.set('name', file.name);
+      requestBody.set('upload_session_tag', uploadSessionTag);
       requestBody.set('chunk', chunkBlob);
       const response = await fetch(`/api/files/upload-chunk`, {
         method: 'POST',
@@ -110,6 +117,7 @@ export function useUploadQueue({
     if (serviceWorker) {
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
+        sessionTag: uploadSessionTag,
         items: items.map(item => ({
           ...item,
           pathInView

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -1,0 +1,140 @@
+import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+export function useUploadQueue({
+  isEnabled,
+  path,
+  files,
+  directories
+}) {
+  const isUploading = useSignal(false);
+  const uploadProgress = useSignal('');
+  useEffect(() => {
+    if (!isEnabled || !('serviceWorker' in navigator)) {
+      return;
+    }
+    const uploadChannel = new BroadcastChannel('bewcloud-uploads');
+    uploadChannel.onmessage = event => {
+      const state = event.data;
+      if (!state || state.type !== 'STATE') {
+        return;
+      }
+      isUploading.value = state.isUploading;
+      uploadProgress.value = state.uploadProgress || '';
+      if (state.error) {
+        console.error(new Error(state.error));
+      }
+      if (state.newFiles && state.pathInView === path.value) {
+        files.value = [...state.newFiles];
+      }
+      if (state.newDirectories && state.pathInView === path.value) {
+        directories.value = [...state.newDirectories];
+      }
+    };
+    async function queryUploadState() {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        registration.active?.postMessage({
+          type: 'QUERY_STATE'
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    queryUploadState();
+    return () => {
+      uploadChannel.close();
+    };
+  }, []);
+  async function uploadFileSingle(file, parentPath, pathInView) {
+    const requestBody = new FormData();
+    requestBody.set('path_in_view', pathInView);
+    requestBody.set('parent_path', parentPath);
+    requestBody.set('name', file.name);
+    requestBody.set('contents', file);
+    const response = await fetch(`/api/files/upload`, {
+      method: 'POST',
+      body: requestBody
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+    }
+    const result = await response.json();
+    if (!result.success) {
+      throw new Error('Failed to upload file!');
+    }
+    files.value = [...result.newFiles];
+    directories.value = [...result.newDirectories];
+  }
+  async function uploadFileChunked(file, parentPath, pathInView) {
+    const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
+    const uploadId = crypto.randomUUID();
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+      uploadProgress.value = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+      const start = chunkIndex * CHUNK_SIZE_BYTES;
+      const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
+      const chunkBlob = file.slice(start, end);
+      const requestBody = new FormData();
+      requestBody.set('upload_id', uploadId);
+      requestBody.set('chunk_index', String(chunkIndex));
+      requestBody.set('total_chunks', String(totalChunks));
+      requestBody.set('path_in_view', pathInView);
+      requestBody.set('parent_path', parentPath);
+      requestBody.set('name', file.name);
+      requestBody.set('chunk', chunkBlob);
+      const response = await fetch(`/api/files/upload-chunk`, {
+        method: 'POST',
+        body: requestBody
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`);
+      }
+      const result = await response.json();
+      if (!result.success) {
+        throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+      }
+      if (result.isComplete) {
+        files.value = [...result.newFiles];
+        directories.value = [...result.newDirectories];
+      }
+    }
+  }
+  function enqueueUpload(items) {
+    if (items.length === 0) {
+      return;
+    }
+    const pathInView = path.value;
+    isUploading.value = true;
+    uploadProgress.value = '';
+    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
+    if (serviceWorker) {
+      serviceWorker.postMessage({
+        type: 'ENQUEUE_UPLOAD',
+        items: items.map(item => ({
+          ...item,
+          pathInView
+        }))
+      });
+      return;
+    }
+    (async () => {
+      for (const item of items) {
+        try {
+          if (item.file.size >= CHUNK_SIZE_BYTES) {
+            await uploadFileChunked(item.file, item.parentPath, pathInView);
+          } else {
+            await uploadFileSingle(item.file, item.parentPath, pathInView);
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      }
+      isUploading.value = false;
+    })();
+  }
+  return {
+    isUploading,
+    uploadProgress,
+    enqueueUpload
+  };
+}

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -25,7 +25,7 @@ export function useUploadQueue({
       if (state.sessionTag && state.sessionTag !== uploadSessionTag) {
         return;
       }
-      isUploading.value = Boolean(state.kindsInProgress?.includes(uploadKind));
+      isUploading.value = state.kindsInProgress ? state.kindsInProgress.includes(uploadKind) : state.isUploading;
       uploadProgress.value = state.kind === uploadKind ? state.uploadProgress || '' : '';
       if (state.error && state.kind === uploadKind) {
         console.error(new Error(state.error));
@@ -116,7 +116,8 @@ export function useUploadQueue({
       };
       const response = await fetch('/api/files/get', {
         method: 'POST',
-        body: JSON.stringify(requestBody)
+        body: JSON.stringify(requestBody),
+        signal: AbortSignal.timeout(10_000)
       });
       if (!response.ok) {
         return new Set();
@@ -132,6 +133,7 @@ export function useUploadQueue({
     if (items.length === 0) {
       return;
     }
+    const pathInView = path.value;
     isUploading.value = true;
     uploadProgress.value = '';
     uploadError.value = '';
@@ -148,7 +150,6 @@ export function useUploadQueue({
       isUploading.value = false;
       return;
     }
-    const pathInView = path.value;
     const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
     if (serviceWorker) {
       serviceWorker.postMessage({

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -6,7 +6,8 @@ export function useUploadQueue({
   path,
   files,
   directories,
-  uploadSessionTag = ''
+  uploadSessionTag = '',
+  uploadKind = 'upload'
 }) {
   const isUploading = useSignal(false);
   const uploadProgress = useSignal('');
@@ -24,9 +25,9 @@ export function useUploadQueue({
       if (state.sessionTag && state.sessionTag !== uploadSessionTag) {
         return;
       }
-      isUploading.value = state.isUploading;
-      uploadProgress.value = state.uploadProgress || '';
-      if (state.error) {
+      isUploading.value = Boolean(state.kindsInProgress?.includes(uploadKind));
+      uploadProgress.value = state.kind === uploadKind ? state.uploadProgress || '' : '';
+      if (state.error && state.kind === uploadKind) {
         console.error(new Error(state.error));
         uploadError.value = state.error;
       }
@@ -108,7 +109,22 @@ export function useUploadQueue({
       }
     }
   }
-  function enqueueUpload(items) {
+  async function getActiveServiceWorker() {
+    if (!isEnabled || !('serviceWorker' in navigator)) {
+      return undefined;
+    }
+    if (navigator.serviceWorker.controller) {
+      return navigator.serviceWorker.controller;
+    }
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      return registration.active ?? undefined;
+    } catch (error) {
+      console.error(error);
+      return undefined;
+    }
+  }
+  async function enqueueUpload(items) {
     if (items.length === 0) {
       return;
     }
@@ -116,33 +132,32 @@ export function useUploadQueue({
     isUploading.value = true;
     uploadProgress.value = '';
     uploadError.value = '';
-    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
+    const serviceWorker = await getActiveServiceWorker();
     if (serviceWorker) {
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
         sessionTag: uploadSessionTag,
         items: items.map(item => ({
           ...item,
-          pathInView
+          pathInView,
+          kind: uploadKind
         }))
       });
       return;
     }
-    (async () => {
-      for (const item of items) {
-        try {
-          if (item.file.size >= CHUNK_SIZE_BYTES) {
-            await uploadFileChunked(item.file, item.parentPath, pathInView);
-          } else {
-            await uploadFileSingle(item.file, item.parentPath, pathInView);
-          }
-        } catch (error) {
-          console.error(error);
-          uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
+    for (const item of items) {
+      try {
+        if (item.file.size >= CHUNK_SIZE_BYTES) {
+          await uploadFileChunked(item.file, item.parentPath, pathInView);
+        } else {
+          await uploadFileSingle(item.file, item.parentPath, pathInView);
         }
+      } catch (error) {
+        console.error(error);
+        uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
       }
-      isUploading.value = false;
-    })();
+    }
+    isUploading.value = false;
   }
   return {
     isUploading,

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -7,7 +7,7 @@ export function useUploadQueue({
   files,
   directories,
   uploadSessionTag = '',
-  uploadKind = 'upload'
+  uploadKind = 'file'
 }) {
   const isUploading = useSignal(false);
   const uploadProgress = useSignal('');
@@ -109,35 +109,52 @@ export function useUploadQueue({
       }
     }
   }
-  async function getActiveServiceWorker() {
-    if (!isEnabled || !('serviceWorker' in navigator)) {
-      return undefined;
-    }
-    if (navigator.serviceWorker.controller) {
-      return navigator.serviceWorker.controller;
-    }
+  async function findExistingNames(parentPath) {
     try {
-      const registration = await navigator.serviceWorker.ready;
-      return registration.active ?? undefined;
+      const requestBody = {
+        parentPath
+      };
+      const response = await fetch('/api/files/get', {
+        method: 'POST',
+        body: JSON.stringify(requestBody)
+      });
+      if (!response.ok) {
+        return new Set();
+      }
+      const result = await response.json();
+      return new Set(result.files.map(file => file.file_name));
     } catch (error) {
       console.error(error);
-      return undefined;
+      return new Set();
     }
   }
   async function enqueueUpload(items) {
     if (items.length === 0) {
       return;
     }
-    const pathInView = path.value;
     isUploading.value = true;
     uploadProgress.value = '';
     uploadError.value = '';
-    const serviceWorker = await getActiveServiceWorker();
+    const uniqueParentPaths = [...new Set(items.map(item => item.parentPath))];
+    const existingNamesByParentPath = new Map(await Promise.all(uniqueParentPaths.map(async parentPath => [parentPath, await findExistingNames(parentPath)])));
+    const itemsToUpload = items.filter(item => {
+      if (existingNamesByParentPath.get(item.parentPath)?.has(item.file.name)) {
+        uploadError.value = `${item.file.name}: A file with this name already exists.`;
+        return false;
+      }
+      return true;
+    });
+    if (itemsToUpload.length === 0) {
+      isUploading.value = false;
+      return;
+    }
+    const pathInView = path.value;
+    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
     if (serviceWorker) {
       serviceWorker.postMessage({
         type: 'ENQUEUE_UPLOAD',
         sessionTag: uploadSessionTag,
-        items: items.map(item => ({
+        items: itemsToUpload.map(item => ({
           ...item,
           pathInView,
           kind: uploadKind
@@ -145,7 +162,7 @@ export function useUploadQueue({
       });
       return;
     }
-    for (const item of items) {
+    for (const item of itemsToUpload) {
       try {
         if (item.file.size >= CHUNK_SIZE_BYTES) {
           await uploadFileChunked(item.file, item.parentPath, pathInView);

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -1,6 +1,22 @@
 import { useSignal } from '@preact/signals';
 import { useEffect } from 'preact/hooks';
 const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+export async function postToUploadServiceWorker(message) {
+  if (!('serviceWorker' in navigator)) {
+    return false;
+  }
+  try {
+    const registration = await Promise.race([navigator.serviceWorker.ready, new Promise(resolve => setTimeout(resolve, 5_000))]);
+    if (!registration?.active) {
+      return false;
+    }
+    registration.active.postMessage(message);
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
 export function useUploadQueue({
   isEnabled,
   path,
@@ -38,18 +54,10 @@ export function useUploadQueue({
         directories.value = [...state.newDirectories];
       }
     };
-    async function queryUploadState() {
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        registration.active?.postMessage({
-          type: 'QUERY_STATE',
-          sessionTag: uploadSessionTag
-        });
-      } catch (error) {
-        console.error(error);
-      }
-    }
-    queryUploadState();
+    postToUploadServiceWorker({
+      type: 'QUERY_STATE',
+      sessionTag: uploadSessionTag
+    });
     return () => {
       uploadChannel.close();
     };
@@ -150,17 +158,16 @@ export function useUploadQueue({
       isUploading.value = false;
       return;
     }
-    const serviceWorker = isEnabled ? navigator.serviceWorker?.controller : undefined;
-    if (serviceWorker) {
-      serviceWorker.postMessage({
-        type: 'ENQUEUE_UPLOAD',
-        sessionTag: uploadSessionTag,
-        items: itemsToUpload.map(item => ({
-          ...item,
-          pathInView,
-          kind: uploadKind
-        }))
-      });
+    const wasEnqueuedInServiceWorker = isEnabled && (await postToUploadServiceWorker({
+      type: 'ENQUEUE_UPLOAD',
+      sessionTag: uploadSessionTag,
+      items: itemsToUpload.map(item => ({
+        ...item,
+        pathInView,
+        kind: uploadKind
+      }))
+    }));
+    if (wasEnqueuedInServiceWorker) {
       return;
     }
     for (const item of itemsToUpload) {

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -1,5 +1,5 @@
 import { useSignal } from '@preact/signals';
-import { useUploadQueue } from '/components/files/useUploadQueue.ts';
+import { useUploadQueue } from "/public/components/files/useUploadQueue.js";
 import ListFiles from "/public/components/files/ListFiles.js";
 import FilesBreadcrumb from "/public/components/files/FilesBreadcrumb.js";
 import CreateDirectoryModal from "/public/components/files/CreateDirectoryModal.js";
@@ -7,7 +7,8 @@ import CreateNoteModal from "./CreateNoteModal.js";
 export default function MainNotes({
   initialDirectories,
   initialFiles,
-  initialPath
+  initialPath,
+  uploadSessionTag
 }) {
   const isAdding = useSignal(false);
   const isDeleting = useSignal(false);
@@ -24,7 +25,8 @@ export default function MainNotes({
     isEnabled: true,
     path,
     files,
-    directories
+    directories,
+    uploadSessionTag
   });
   function onClickCreateNote() {
     if (isNewNoteModalOpen.value) {

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -20,6 +20,7 @@ export default function MainNotes({
   const isNewDirectoryModalOpen = useSignal(false);
   const {
     isUploading: isCreatingNote,
+    uploadError: createNoteError,
     enqueueUpload
   } = useUploadQueue({
     isEnabled: true,
@@ -214,7 +215,9 @@ export default function MainNotes({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Creating...") : null, !isDeleting.value && !isAdding.value && !isCreatingNote.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
+  }), "Creating...") : null, !isDeleting.value && !isAdding.value && !isCreatingNote.value ? h(Fragment, null, "\xA0") : null), createNoteError.value ? h("span", {
+    class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
+  }, "Creating the note failed \u2014 ", createNoteError.value) : null), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -1,4 +1,5 @@
 import { useSignal } from '@preact/signals';
+import { useUploadQueue } from '/components/files/useUploadQueue.ts';
 import ListFiles from "/public/components/files/ListFiles.js";
 import FilesBreadcrumb from "/public/components/files/FilesBreadcrumb.js";
 import CreateDirectoryModal from "/public/components/files/CreateDirectoryModal.js";
@@ -16,6 +17,15 @@ export default function MainNotes({
   const areNewOptionsOption = useSignal(false);
   const isNewNoteModalOpen = useSignal(false);
   const isNewDirectoryModalOpen = useSignal(false);
+  const {
+    isUploading: isCreatingNote,
+    enqueueUpload
+  } = useUploadQueue({
+    isEnabled: true,
+    path,
+    files,
+    directories
+  });
   function onClickCreateNote() {
     if (isNewNoteModalOpen.value) {
       isNewNoteModalOpen.value = false;
@@ -23,38 +33,19 @@ export default function MainNotes({
     }
     isNewNoteModalOpen.value = true;
   }
-  async function onClickSaveNote(newNoteName) {
-    if (isAdding.value) {
-      return;
-    }
+  function onClickSaveNote(newNoteName) {
     if (!newNoteName) {
       return;
     }
     areNewOptionsOption.value = false;
-    isAdding.value = true;
-    const requestBody = new FormData();
-    requestBody.set('parent_path', path.value);
-    requestBody.set('path_in_view', path.value);
-    requestBody.set('name', `${newNoteName}.md`);
-    requestBody.set('contents', `# ${newNoteName}\n\nStart your new note!\n`);
-    try {
-      const response = await fetch(`/api/files/upload`, {
-        method: 'POST',
-        body: requestBody
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to create note. ${response.statusText} ${await response.text()}`);
-      }
-      const result = await response.json();
-      if (!result.success) {
-        throw new Error('Failed to create note!');
-      }
-      files.value = [...result.newFiles];
-      isNewNoteModalOpen.value = false;
-    } catch (error) {
-      console.error(error);
-    }
-    isAdding.value = false;
+    isNewNoteModalOpen.value = false;
+    const noteFile = new File([`# ${newNoteName}\n\nStart your new note!\n`], `${newNoteName}.md`, {
+      type: 'text/markdown'
+    });
+    enqueueUpload([{
+      file: noteFile,
+      parentPath: path.value
+    }]);
   }
   function onCloseCreateNote() {
     isNewNoteModalOpen.value = false;
@@ -182,7 +173,7 @@ export default function MainNotes({
   }, h("img", {
     src: "/public/images/add.svg",
     alt: "Add new note or directory",
-    class: `white ${isAdding.value ? 'animate-spin' : ''}`,
+    class: `white ${isAdding.value || isCreatingNote.value ? 'animate-spin' : ''}`,
     width: 20,
     height: 20
   }))), h("div", {
@@ -216,12 +207,12 @@ export default function MainNotes({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Deleting...") : null, isAdding.value ? h(Fragment, null, h("img", {
+  }), "Deleting...") : null, isAdding.value || isCreatingNote.value ? h(Fragment, null, h("img", {
     src: "/public/images/loading.svg",
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Creating...") : null, !isDeleting.value && !isAdding.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
+  }), "Creating...") : null, !isDeleting.value && !isAdding.value && !isCreatingNote.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -27,7 +27,8 @@ export default function MainNotes({
     path,
     files,
     directories,
-    uploadSessionTag
+    uploadSessionTag,
+    uploadKind: 'note'
   });
   function onClickCreateNote() {
     if (isNewNoteModalOpen.value) {

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -1,5 +1,5 @@
 import { useSignal } from '@preact/signals';
-import { useUploadQueue } from "/public/components/files/useUploadQueue.js";
+import { postToUploadServiceWorker, useUploadQueue } from "/public/components/files/useUploadQueue.js";
 import ListFiles from "/public/components/files/ListFiles.js";
 import FilesBreadcrumb from "/public/components/files/FilesBreadcrumb.js";
 import CreateDirectoryModal from "/public/components/files/CreateDirectoryModal.js";
@@ -122,6 +122,11 @@ export default function MainNotes({
           throw new Error('Failed to delete directory!');
         }
         directories.value = [...result.newDirectories];
+        await postToUploadServiceWorker({
+          type: 'DIRECTORY_DELETED',
+          sessionTag: uploadSessionTag ?? '',
+          path: `${parentPath}${name}/`
+        });
       } catch (error) {
         console.error(error);
       }

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -1,5 +1,5 @@
 import { useSignal } from '@preact/signals';
-import { useUploadQueue } from '/components/files/useUploadQueue.ts';
+import { useUploadQueue } from "/public/components/files/useUploadQueue.js";
 import CreateDirectoryModal from "/public/components/files/CreateDirectoryModal.js";
 import ListFiles from "/public/components/files/ListFiles.js";
 import FilesBreadcrumb from "/public/components/files/FilesBreadcrumb.js";
@@ -7,7 +7,8 @@ import ListPhotos from "/public/components/photos/ListPhotos.js";
 export default function MainPhotos({
   initialDirectories,
   initialFiles,
-  initialPath
+  initialPath,
+  uploadSessionTag
 }) {
   const isAdding = useSignal(false);
   const directories = useSignal(initialDirectories);
@@ -23,7 +24,8 @@ export default function MainPhotos({
     isEnabled: true,
     path,
     files,
-    directories
+    directories,
+    uploadSessionTag
   });
   function onClickUploadFile() {
     const fileInput = document.createElement('input');

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -19,6 +19,7 @@ export default function MainPhotos({
   const {
     isUploading,
     uploadProgress,
+    uploadError,
     enqueueUpload
   } = useUploadQueue({
     isEnabled: true,
@@ -150,7 +151,9 @@ export default function MainPhotos({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), uploadProgress.value || 'Uploading...') : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
+  }), uploadProgress.value || 'Uploading...') : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
+    class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
+  }, "Upload failed \u2014 ", uploadError.value) : null), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -1,4 +1,5 @@
 import { useSignal } from '@preact/signals';
+import { useUploadQueue } from '/components/files/useUploadQueue.ts';
 import CreateDirectoryModal from "/public/components/files/CreateDirectoryModal.js";
 import ListFiles from "/public/components/files/ListFiles.js";
 import FilesBreadcrumb from "/public/components/files/FilesBreadcrumb.js";
@@ -9,50 +10,38 @@ export default function MainPhotos({
   initialPath
 }) {
   const isAdding = useSignal(false);
-  const isUploading = useSignal(false);
   const directories = useSignal(initialDirectories);
   const files = useSignal(initialFiles);
   const path = useSignal(initialPath);
   const areNewOptionsOption = useSignal(false);
   const isNewDirectoryModalOpen = useSignal(false);
+  const {
+    isUploading,
+    uploadProgress,
+    enqueueUpload
+  } = useUploadQueue({
+    isEnabled: true,
+    path,
+    files,
+    directories
+  });
   function onClickUploadFile() {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
     fileInput.multiple = true;
     fileInput.accept = 'image/*,video/*';
     fileInput.click();
-    fileInput.onchange = async event => {
+    fileInput.onchange = event => {
       const chosenFilesList = event.target?.files;
-      const chosenFiles = Array.from(chosenFilesList);
-      isUploading.value = true;
-      for (const chosenFile of chosenFiles) {
-        if (!chosenFile) {
-          continue;
-        }
-        areNewOptionsOption.value = false;
-        const requestBody = new FormData();
-        requestBody.set('parent_path', path.value);
-        requestBody.set('path_in_view', path.value);
-        requestBody.set('name', chosenFile.name);
-        requestBody.set('contents', chosenFile);
-        try {
-          const response = await fetch(`/api/files/upload`, {
-            method: 'POST',
-            body: requestBody
-          });
-          if (!response.ok) {
-            throw new Error(`Failed to upload photo. ${response.statusText} ${await response.text()}`);
-          }
-          const result = await response.json();
-          if (!result.success) {
-            throw new Error('Failed to upload photo!');
-          }
-          files.value = [...result.newFiles];
-        } catch (error) {
-          console.error(error);
-        }
+      const chosenFiles = Array.from(chosenFilesList).filter(Boolean);
+      if (chosenFiles.length === 0) {
+        return;
       }
-      isUploading.value = false;
+      areNewOptionsOption.value = false;
+      enqueueUpload(chosenFiles.map(chosenFile => ({
+        file: chosenFile,
+        parentPath: path.value
+      })));
     };
   }
   function onClickCreateDirectory() {
@@ -159,7 +148,7 @@ export default function MainPhotos({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), "Uploading...") : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
+  }), uploadProgress.value || 'Uploading...') : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null)), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -26,7 +26,8 @@ export default function MainPhotos({
     path,
     files,
     directories,
-    uploadSessionTag
+    uploadSessionTag,
+    uploadKind: 'photo'
   });
   function onClickUploadFile() {
     const fileInput = document.createElement('input');

--- a/public/css/tailwind.css
+++ b/public/css/tailwind.css
@@ -244,6 +244,9 @@
   }
 }
 @layer utilities {
+  .collapse {
+    visibility: collapse;
+  }
   .invisible {
     visibility: hidden;
   }

--- a/public/css/tailwind.css
+++ b/public/css/tailwind.css
@@ -1161,6 +1161,9 @@
   .text-green-600 {
     color: var(--color-green-600);
   }
+  .text-red-400 {
+    color: var(--color-red-400);
+  }
   .text-sky-500 {
     color: var(--color-sky-500);
   }

--- a/public/css/tailwind.css
+++ b/public/css/tailwind.css
@@ -282,6 +282,9 @@
   .top-0 {
     top: 0px;
   }
+  .top-1 {
+    top: var(--spacing);
+  }
   .top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
@@ -290,6 +293,9 @@
   }
   .left-0 {
     left: 0px;
+  }
+  .left-1 {
+    left: var(--spacing);
   }
   .left-1\/2 {
     left: calc(1 / 2 * 100%);
@@ -481,6 +487,9 @@
     width: calc(var(--spacing) * 6);
     height: calc(var(--spacing) * 6);
   }
+  .h-1 {
+    height: var(--spacing);
+  }
   .h-1\.5 {
     height: calc(var(--spacing) * 1.5);
   }
@@ -643,6 +652,9 @@
   .flex-none {
     flex: none;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .shrink-0 {
     flex-shrink: 0;
   }
@@ -655,8 +667,16 @@
   .origin-top-right {
     transform-origin: 100% 0;
   }
+  .-translate-x-1 {
+    --tw-translate-x: calc(var(--spacing) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-1 {
+    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -738,6 +758,9 @@
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
+  }
+  .gap-x-1 {
+    column-gap: var(--spacing);
   }
   .gap-x-1\.5 {
     column-gap: calc(var(--spacing) * 1.5);
@@ -1221,6 +1244,9 @@
   .ring-1 {
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring-black {
+    --tw-ring-color: var(--color-black);
   }
   .ring-black\/15 {
     --tw-ring-color: color-mix(in srgb, #000 15%, transparent);

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,8 @@
 
 const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
 const BROADCAST_CHANNEL_NAME = 'bewcloud-uploads';
+// If the server dies mid-request (a restart/deploy), the socket can sit open with no RST and no response for minutes, so a plain fetch() neither resolves nor rejects: nothing left to catch, the queue never finishes, and the UI is stuck on "Uploading" forever. A timeout guarantees the request eventually fails instead.
+const REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 
 const broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
 
@@ -42,6 +44,30 @@ function throwIfUploadSessionIsGone(response) {
   }
 }
 
+// fetch() tied to the job's own AbortController so the request cancels when the job is abandoned, plus a timeout so a server that's gone dark doesn't hang it forever.
+async function fetchForJob(job, url, options) {
+  const timeoutController = new AbortController();
+
+  if (job.abortController.signal.aborted) {
+    timeoutController.abort();
+  }
+
+  const onJobAbort = () => timeoutController.abort();
+  job.abortController.signal.addEventListener('abort', onJobAbort);
+
+  const timeoutId = setTimeout(
+    () => timeoutController.abort(new Error(`Request to ${url} timed out`)),
+    REQUEST_TIMEOUT_MS,
+  );
+
+  try {
+    return await fetch(url, { ...options, signal: timeoutController.signal });
+  } finally {
+    clearTimeout(timeoutId);
+    job.abortController.signal.removeEventListener('abort', onJobAbort);
+  }
+}
+
 async function uploadFileSingle(job, file, parentPath, pathInView) {
   const requestBody = new FormData();
   requestBody.set('path_in_view', pathInView);
@@ -50,11 +76,7 @@ async function uploadFileSingle(job, file, parentPath, pathInView) {
   requestBody.set('upload_session_tag', job.sessionTag);
   requestBody.set('contents', file);
 
-  const response = await fetch('/api/files/upload', {
-    method: 'POST',
-    body: requestBody,
-    signal: job.abortController.signal,
-  });
+  const response = await fetchForJob(job, '/api/files/upload', { method: 'POST', body: requestBody });
 
   throwIfUploadSessionIsGone(response);
 
@@ -65,7 +87,7 @@ async function uploadFileSingle(job, file, parentPath, pathInView) {
   const result = await response.json();
 
   if (!result.success) {
-    throw new Error('Failed to upload file!');
+    throw new Error(result.error || 'Failed to upload file!');
   }
 
   return { newFiles: result.newFiles, newDirectories: result.newDirectories };
@@ -95,11 +117,7 @@ async function uploadFileChunked(job, file, parentPath, pathInView) {
     requestBody.set('upload_session_tag', job.sessionTag);
     requestBody.set('chunk', chunkBlob);
 
-    const response = await fetch('/api/files/upload-chunk', {
-      method: 'POST',
-      body: requestBody,
-      signal: job.abortController.signal,
-    });
+    const response = await fetchForJob(job, '/api/files/upload-chunk', { method: 'POST', body: requestBody });
 
     throwIfUploadSessionIsGone(response);
 
@@ -112,7 +130,7 @@ async function uploadFileChunked(job, file, parentPath, pathInView) {
     const result = await response.json();
 
     if (!result.success) {
-      throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+      throw new Error(result.error || `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
     }
 
     if (result.isComplete) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,10 @@ const BROADCAST_CHANNEL_NAME = 'bewcloud-uploads';
 
 const broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
 
-let currentJob = null; // { queue: [{ file, parentPath, pathInView }], uploadProgress }
+let currentJob = null; // { queue: [{ file, parentPath, pathInView }], uploadProgress, sessionTag, abortController }
+
+// A queue outlives the session that created it, so the upload endpoints refuse requests tagged with a session other than the one their cookie now belongs to. When that happens there's nothing left to retry: the rest of the queue is dropped instead of being uploaded as whoever is logged in now.
+class UploadSessionGoneError extends Error {}
 
 self.addEventListener('install', () => {
   self.skipWaiting();
@@ -20,18 +23,40 @@ function broadcastState(extra = {}) {
     type: 'STATE',
     isUploading: Boolean(currentJob),
     uploadProgress: currentJob?.uploadProgress || '',
+    sessionTag: currentJob?.sessionTag || '',
     ...extra,
   });
 }
 
-async function uploadFileSingle(file, parentPath, pathInView) {
+function abandonCurrentJob() {
+  currentJob?.abortController.abort();
+  currentJob = null;
+
+  broadcastState();
+}
+
+// A 403 is the endpoints refusing this queue's session tag, and a redirect means there's no session left at all (the request was bounced to the login page).
+function throwIfUploadSessionIsGone(response) {
+  if (response.status === 403 || response.redirected) {
+    throw new UploadSessionGoneError('upload cancelled, this session is no longer valid');
+  }
+}
+
+async function uploadFileSingle(job, file, parentPath, pathInView) {
   const requestBody = new FormData();
   requestBody.set('path_in_view', pathInView);
   requestBody.set('parent_path', parentPath);
   requestBody.set('name', file.name);
+  requestBody.set('upload_session_tag', job.sessionTag);
   requestBody.set('contents', file);
 
-  const response = await fetch('/api/files/upload', { method: 'POST', body: requestBody });
+  const response = await fetch('/api/files/upload', {
+    method: 'POST',
+    body: requestBody,
+    signal: job.abortController.signal,
+  });
+
+  throwIfUploadSessionIsGone(response);
 
   if (!response.ok) {
     throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
@@ -46,14 +71,14 @@ async function uploadFileSingle(file, parentPath, pathInView) {
   return { newFiles: result.newFiles, newDirectories: result.newDirectories };
 }
 
-async function uploadFileChunked(file, parentPath, pathInView) {
+async function uploadFileChunked(job, file, parentPath, pathInView) {
   const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
   const uploadId = crypto.randomUUID();
 
   let completedResult = null;
 
   for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-    currentJob.uploadProgress = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+    job.uploadProgress = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
     broadcastState();
 
     const start = chunkIndex * CHUNK_SIZE_BYTES;
@@ -67,9 +92,16 @@ async function uploadFileChunked(file, parentPath, pathInView) {
     requestBody.set('path_in_view', pathInView);
     requestBody.set('parent_path', parentPath);
     requestBody.set('name', file.name);
+    requestBody.set('upload_session_tag', job.sessionTag);
     requestBody.set('chunk', chunkBlob);
 
-    const response = await fetch('/api/files/upload-chunk', { method: 'POST', body: requestBody });
+    const response = await fetch('/api/files/upload-chunk', {
+      method: 'POST',
+      body: requestBody,
+      signal: job.abortController.signal,
+    });
+
+    throwIfUploadSessionIsGone(response);
 
     if (!response.ok) {
       throw new Error(
@@ -91,24 +123,41 @@ async function uploadFileChunked(file, parentPath, pathInView) {
   return completedResult;
 }
 
-async function processQueue() {
-  while (currentJob.queue.length > 0) {
-    const { file, parentPath, pathInView } = currentJob.queue.shift();
+async function processQueue(job) {
+  while (job.queue.length > 0) {
+    const { file, parentPath, pathInView } = job.queue.shift();
 
-    currentJob.uploadProgress = '';
+    job.uploadProgress = '';
     broadcastState();
 
     try {
       const result = file.size >= CHUNK_SIZE_BYTES
-        ? await uploadFileChunked(file, parentPath, pathInView)
-        : await uploadFileSingle(file, parentPath, pathInView);
+        ? await uploadFileChunked(job, file, parentPath, pathInView)
+        : await uploadFileSingle(job, file, parentPath, pathInView);
 
       if (result) {
         broadcastState({ ...result, pathInView });
       }
     } catch (error) {
+      // The job was already abandoned while this upload was in flight, so its aborted fetch has nothing left to report.
+      if (currentJob !== job) {
+        return;
+      }
+
+      if (error instanceof UploadSessionGoneError) {
+        const droppedCount = job.queue.length + 1;
+
+        console.error(error);
+        broadcastState({
+          error: `${file.name}: ${error.message} (${droppedCount} upload${droppedCount === 1 ? '' : 's'} dropped).`,
+        });
+        abandonCurrentJob();
+
+        return;
+      }
+
       console.error(error);
-      broadcastState({ error: String(error?.message || error) });
+      broadcastState({ error: `${file.name}: ${String(error?.message || error)}` });
     }
   }
 
@@ -123,11 +172,20 @@ self.addEventListener('message', (event) => {
     return;
   }
 
+  if (currentJob && message.sessionTag !== currentJob.sessionTag) {
+    abandonCurrentJob();
+  }
+
   if (message.type === 'ENQUEUE_UPLOAD') {
     const isNewJob = !currentJob;
 
     if (isNewJob) {
-      currentJob = { queue: [], uploadProgress: '' };
+      currentJob = {
+        queue: [],
+        uploadProgress: '',
+        sessionTag: message.sessionTag,
+        abortController: new AbortController(),
+      };
     }
 
     currentJob.queue.push(...message.items);
@@ -136,7 +194,7 @@ self.addEventListener('message', (event) => {
 
     if (isNewJob) {
       // 'message' events only keep this worker alive for as long as the handler is extended: without waitUntil, the browser can terminate the worker before processQueue's first fetch() even starts.
-      event.waitUntil(processQueue());
+      event.waitUntil(processQueue(currentJob));
     }
   } else if (message.type === 'QUERY_STATE') {
     broadcastState();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,144 @@
+// Drives file uploads so they keep running across a page refresh: the fetch() calls that upload each file/chunk live here instead of in the page's JS, and this worker keeps executing through a same-tab reload. The page enqueues files and listens for progress on a BroadcastChannel; on mount (including right after a refresh) it queries this worker for any job already in flight.
+
+const CHUNK_SIZE_BYTES = 10 * 1024 * 1024;
+const BROADCAST_CHANNEL_NAME = 'bewcloud-uploads';
+
+const broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+
+let currentJob = null; // { queue: [{ file, parentPath, pathInView }], uploadProgress }
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+function broadcastState(extra = {}) {
+  broadcastChannel.postMessage({
+    type: 'STATE',
+    isUploading: Boolean(currentJob),
+    uploadProgress: currentJob?.uploadProgress || '',
+    ...extra,
+  });
+}
+
+async function uploadFileSingle(file, parentPath, pathInView) {
+  const requestBody = new FormData();
+  requestBody.set('path_in_view', pathInView);
+  requestBody.set('parent_path', parentPath);
+  requestBody.set('name', file.name);
+  requestBody.set('contents', file);
+
+  const response = await fetch('/api/files/upload', { method: 'POST', body: requestBody });
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload file. ${response.statusText} ${await response.text()}`);
+  }
+
+  const result = await response.json();
+
+  if (!result.success) {
+    throw new Error('Failed to upload file!');
+  }
+
+  return { newFiles: result.newFiles, newDirectories: result.newDirectories };
+}
+
+async function uploadFileChunked(file, parentPath, pathInView) {
+  const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
+  const uploadId = crypto.randomUUID();
+
+  let completedResult = null;
+
+  for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+    currentJob.uploadProgress = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+    broadcastState();
+
+    const start = chunkIndex * CHUNK_SIZE_BYTES;
+    const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
+    const chunkBlob = file.slice(start, end);
+
+    const requestBody = new FormData();
+    requestBody.set('upload_id', uploadId);
+    requestBody.set('chunk_index', String(chunkIndex));
+    requestBody.set('total_chunks', String(totalChunks));
+    requestBody.set('path_in_view', pathInView);
+    requestBody.set('parent_path', parentPath);
+    requestBody.set('name', file.name);
+    requestBody.set('chunk', chunkBlob);
+
+    const response = await fetch('/api/files/upload-chunk', { method: 'POST', body: requestBody });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to upload chunk ${chunkIndex + 1}/${totalChunks}. ${response.statusText} ${await response.text()}`,
+      );
+    }
+
+    const result = await response.json();
+
+    if (!result.success) {
+      throw new Error(`Failed to upload chunk ${chunkIndex + 1}/${totalChunks}!`);
+    }
+
+    if (result.isComplete) {
+      completedResult = { newFiles: result.newFiles, newDirectories: result.newDirectories };
+    }
+  }
+
+  return completedResult;
+}
+
+async function processQueue() {
+  while (currentJob.queue.length > 0) {
+    const { file, parentPath, pathInView } = currentJob.queue.shift();
+
+    currentJob.uploadProgress = '';
+    broadcastState();
+
+    try {
+      const result = file.size >= CHUNK_SIZE_BYTES
+        ? await uploadFileChunked(file, parentPath, pathInView)
+        : await uploadFileSingle(file, parentPath, pathInView);
+
+      if (result) {
+        broadcastState({ ...result, pathInView });
+      }
+    } catch (error) {
+      console.error(error);
+      broadcastState({ error: String(error?.message || error) });
+    }
+  }
+
+  currentJob = null;
+  broadcastState();
+}
+
+self.addEventListener('message', (event) => {
+  const message = event.data;
+
+  if (!message || typeof message !== 'object') {
+    return;
+  }
+
+  if (message.type === 'ENQUEUE_UPLOAD') {
+    const isNewJob = !currentJob;
+
+    if (isNewJob) {
+      currentJob = { queue: [], uploadProgress: '' };
+    }
+
+    currentJob.queue.push(...message.items);
+
+    broadcastState();
+
+    if (isNewJob) {
+      // 'message' events only keep this worker alive for as long as the handler is extended: without waitUntil, the browser can terminate the worker before processQueue's first fetch() even starts.
+      event.waitUntil(processQueue());
+    }
+  } else if (message.type === 'QUERY_STATE') {
+    broadcastState();
+  }
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -43,23 +43,38 @@ function abandonCurrentJob() {
 }
 
 // Best-effort: if a chunked upload was mid-flight when the job got abandoned, tell the server to drop whatever chunks it already received instead of leaving them in .chunk-uploads until the 24h stale sweep.
-function cleanupAbortedChunkUpload(job) {
+async function cleanupAbortedChunkUpload(job) {
   if (!job?.currentUploadId) {
     return;
   }
 
-  fetch('/api/files/upload-abort', {
-    method: 'POST',
-    body: JSON.stringify({ upload_id: job.currentUploadId, upload_session_tag: job.sessionTag }),
-  }).catch(() => {});
+  try {
+    await fetch('/api/files/upload-abort', {
+      method: 'POST',
+      body: JSON.stringify({ upload_id: job.currentUploadId, upload_session_tag: job.sessionTag }),
+    });
+  } catch {
+    // Best-effort only - the 24h stale sweep still catches it if this fails.
+  }
 }
 
-// True if a file still queued (or the one currently mid-flight) would land in the directory that just got deleted, or one of its subdirectories. Paths in this app always end in '/', so a prefix match also covers the exact-match case.
-function isJobAffectedByDeletedPath(job, deletedPath) {
-  const isUnderDeletedPath = (parentPath) => typeof parentPath === 'string' && parentPath.startsWith(deletedPath);
+function isUnderDeletedPath(parentPath, deletedPath) {
+  return typeof parentPath === 'string' && parentPath.startsWith(deletedPath);
+}
 
-  return isUnderDeletedPath(job.currentItemParentPath) ||
-    job.queue.some((item) => isUnderDeletedPath(item.parentPath));
+// Drops queued items that would land in the directory that just got deleted (or a subdirectory of it), without touching queued items for anywhere else. If the item currently mid-flight is itself affected, the whole job is abandoned instead: there's only one AbortController per job, so an in-flight fetch can't be cancelled without cancelling the job's future fetches too.
+function handleDirectoryDeleted(job, deletedPath) {
+  if (isUnderDeletedPath(job.currentItemParentPath, deletedPath)) {
+    abandonCurrentJob();
+    return;
+  }
+
+  const queueLengthBefore = job.queue.length;
+  job.queue = job.queue.filter((item) => !isUnderDeletedPath(item.parentPath, deletedPath));
+
+  if (job.queue.length !== queueLengthBefore) {
+    broadcastState();
+  }
 }
 
 // A 403 is the endpoints refusing this queue's session tag, and a redirect means there's no session left at all (the request was bounced to the login page). The upload endpoints use 503, not 403, when they're refusing for an unrelated reason (the app is disabled), so 403 here means the session specifically.
@@ -241,11 +256,8 @@ self.addEventListener('message', (event) => {
 
   // Sent by the page after it deletes a directory, so a queue still writing into it (or a subdirectory of it) doesn't keep going against a destination that's gone.
   if (message.type === 'DIRECTORY_DELETED') {
-    if (
-      currentJob && message.sessionTag === currentJob.sessionTag &&
-      isJobAffectedByDeletedPath(currentJob, message.path)
-    ) {
-      abandonCurrentJob();
+    if (currentJob && message.sessionTag === currentJob.sessionTag) {
+      handleDirectoryDeleted(currentJob, message.path);
     }
 
     return;

--- a/public/sw.js
+++ b/public/sw.js
@@ -26,6 +26,8 @@ function broadcastState(extra = {}) {
     isUploading: Boolean(currentJob),
     uploadProgress: currentJob?.uploadProgress || '',
     sessionTag: currentJob?.sessionTag || '',
+    kindsInProgress: getKindsInProgress(currentJob),
+    kind: currentJob?.currentItemKind || '',
     ...extra,
   });
 }
@@ -37,11 +39,26 @@ function abandonCurrentJob() {
   broadcastState();
 }
 
-// A 403 is the endpoints refusing this queue's session tag, and a redirect means there's no session left at all (the request was bounced to the login page).
+// A 403 is the endpoints refusing this queue's session tag, and a redirect means there's no session left at all (the request was bounced to the login page). The upload endpoints use 503, not 403, when they're refusing for an unrelated reason (the app is disabled), so 403 here means the session specifically.
 function throwIfUploadSessionIsGone(response) {
   if (response.status === 403 || response.redirected) {
     throw new UploadSessionGoneError('upload cancelled, this session is no longer valid');
   }
+}
+
+// Kinds still represented in the job: whatever's still queued, plus whatever's mid-flight (already shifted off the queue). Lets each tab's hook show "uploading" only for its own kind of upload (e.g. Notes shouldn't light up while Files is uploading).
+function getKindsInProgress(job) {
+  if (!job) {
+    return [];
+  }
+
+  const kinds = new Set(job.queue.map((item) => item.kind || 'upload'));
+
+  if (job.currentItemKind) {
+    kinds.add(job.currentItemKind);
+  }
+
+  return [...kinds];
 }
 
 // fetch() tied to the job's own AbortController so the request cancels when the job is abandoned, plus a timeout so a server that's gone dark doesn't hang it forever.
@@ -143,9 +160,10 @@ async function uploadFileChunked(job, file, parentPath, pathInView) {
 
 async function processQueue(job) {
   while (job.queue.length > 0) {
-    const { file, parentPath, pathInView } = job.queue.shift();
+    const { file, parentPath, pathInView, kind } = job.queue.shift();
 
     job.uploadProgress = '';
+    job.currentItemKind = kind || 'upload';
     broadcastState();
 
     try {
@@ -187,6 +205,11 @@ self.addEventListener('message', (event) => {
   const message = event.data;
 
   if (!message || typeof message !== 'object') {
+    return;
+  }
+
+  if (message.type === 'ABORT_UPLOADS') {
+    abandonCurrentJob();
     return;
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,10 +33,33 @@ function broadcastState(extra = {}) {
 }
 
 function abandonCurrentJob() {
-  currentJob?.abortController.abort();
+  const job = currentJob;
+
+  job?.abortController.abort();
   currentJob = null;
 
   broadcastState();
+  cleanupAbortedChunkUpload(job);
+}
+
+// Best-effort: if a chunked upload was mid-flight when the job got abandoned, tell the server to drop whatever chunks it already received instead of leaving them in .chunk-uploads until the 24h stale sweep.
+function cleanupAbortedChunkUpload(job) {
+  if (!job?.currentUploadId) {
+    return;
+  }
+
+  fetch('/api/files/upload-abort', {
+    method: 'POST',
+    body: JSON.stringify({ upload_id: job.currentUploadId, upload_session_tag: job.sessionTag }),
+  }).catch(() => {});
+}
+
+// True if a file still queued (or the one currently mid-flight) would land in the directory that just got deleted, or one of its subdirectories. Paths in this app always end in '/', so a prefix match also covers the exact-match case.
+function isJobAffectedByDeletedPath(job, deletedPath) {
+  const isUnderDeletedPath = (parentPath) => typeof parentPath === 'string' && parentPath.startsWith(deletedPath);
+
+  return isUnderDeletedPath(job.currentItemParentPath) ||
+    job.queue.some((item) => isUnderDeletedPath(item.parentPath));
 }
 
 // A 403 is the endpoints refusing this queue's session tag, and a redirect means there's no session left at all (the request was bounced to the login page). The upload endpoints use 503, not 403, when they're refusing for an unrelated reason (the app is disabled), so 403 here means the session specifically.
@@ -113,6 +136,7 @@ async function uploadFileSingle(job, file, parentPath, pathInView) {
 async function uploadFileChunked(job, file, parentPath, pathInView) {
   const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
   const uploadId = crypto.randomUUID();
+  job.currentUploadId = uploadId;
 
   let completedResult = null;
 
@@ -164,6 +188,8 @@ async function processQueue(job) {
 
     job.uploadProgress = '';
     job.currentItemKind = kind || 'file';
+    job.currentItemParentPath = parentPath;
+    job.currentUploadId = undefined;
     broadcastState();
 
     try {
@@ -210,6 +236,18 @@ self.addEventListener('message', (event) => {
 
   if (message.type === 'ABORT_UPLOADS') {
     abandonCurrentJob();
+    return;
+  }
+
+  // Sent by the page after it deletes a directory, so a queue still writing into it (or a subdirectory of it) doesn't keep going against a destination that's gone.
+  if (message.type === 'DIRECTORY_DELETED') {
+    if (
+      currentJob && message.sessionTag === currentJob.sessionTag &&
+      isJobAffectedByDeletedPath(currentJob, message.path)
+    ) {
+      abandonCurrentJob();
+    }
+
     return;
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -52,7 +52,7 @@ function getKindsInProgress(job) {
     return [];
   }
 
-  const kinds = new Set(job.queue.map((item) => item.kind || 'upload'));
+  const kinds = new Set(job.queue.map((item) => item.kind || 'file'));
 
   if (job.currentItemKind) {
     kinds.add(job.currentItemKind);
@@ -163,7 +163,7 @@ async function processQueue(job) {
     const { file, parentPath, pathInView, kind } = job.queue.shift();
 
     job.uploadProgress = '';
-    job.currentItemKind = kind || 'upload';
+    job.currentItemKind = kind || 'file';
     broadcastState();
 
     try {

--- a/public/ts/service-worker.ts
+++ b/public/ts/service-worker.ts
@@ -1,0 +1,12 @@
+// Registers the upload service worker (public/sw.js) so uploads survive a page refresh.
+export async function registerUploadServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  try {
+    await navigator.serviceWorker.register('/public/sw.js', { scope: '/' });
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/routes.ts
+++ b/routes.ts
@@ -222,9 +222,19 @@ const routes: Routes = {
           if (relativePath.startsWith('js/')) {
             response.headers.set('content-type', 'application/javascript; charset=utf-8');
           }
+
+          // The upload service worker is served from under /public/, but needs root scope to observe navigations/API requests across the whole app, not just /public/.
+          if (relativePath === 'sw.js') {
+            response.headers.set('content-type', 'application/javascript; charset=utf-8');
+            response.headers.set('service-worker-allowed', '/');
+          }
         }
 
-        response.headers.set('cache-control', `max-age=${oneDayInSeconds}, public`);
+        // Never cache the service worker script itself: a stale cached copy would keep running for up to a day after a fix is deployed, since the browser won't even ask the server.
+        response.headers.set(
+          'cache-control',
+          relativePath === 'sw.js' ? 'no-cache' : `max-age=${oneDayInSeconds}, public`,
+        );
         return response;
       } catch (error) {
         if ((error as Error).toString().includes('NotFound')) {

--- a/routes.ts
+++ b/routes.ts
@@ -230,10 +230,11 @@ const routes: Routes = {
           }
         }
 
-        // Never cache the service worker script itself: a stale cached copy would keep running for up to a day after a fix is deployed, since the browser won't even ask the server.
+        // Compiled component JS imports other compiled files by path, so a stale cached copy can reference a file that no longer exists after a rebuild (e.g. a renamed/removed component); same risk for the service worker script itself. 'no-cache' still lets the browser reuse the cached body via a 304 (serveFile sets an ETag), it just forces a revalidation request first.
+        const isServedFromComponentsPath = relativePath.startsWith('components/');
         response.headers.set(
           'cache-control',
-          relativePath === 'sw.js' ? 'no-cache' : `max-age=${oneDayInSeconds}, public`,
+          (relativePath === 'sw.js' || isServedFromComponentsPath) ? 'no-cache' : `max-age=${oneDayInSeconds}, public`,
         );
         return response;
       } catch (error) {

--- a/routes.ts
+++ b/routes.ts
@@ -379,6 +379,7 @@ const routes: Routes = {
   apiFilesUpdateShare: createPageRouteHandler('api/files/update-share.ts', '/api/files/update-share'),
   apiFilesUpdateSort: createPageRouteHandler('api/files/update-sort.ts', '/api/files/update-sort'),
   apiFilesUpload: createPageRouteHandler('api/files/upload.ts', '/api/files/upload'),
+  apiFilesUploadAbort: createPageRouteHandler('api/files/upload-abort.ts', '/api/files/upload-abort'),
   apiFilesUploadChunk: createPageRouteHandler('api/files/upload-chunk.ts', '/api/files/upload-chunk'),
 
   apiNewsAddFeed: createPageRouteHandler('api/news/add-feed.ts', '/api/news/add-feed'),


### PR DESCRIPTION
Allows page refreshes (intentional or accidental) during file and directory uploads without interrupting the upload.

I purposely didn't add an opt-in setting for this because I think it's a better upload experience. In situations where service workers aren't available or intentionally disabled, we fall back to the standard upload flow.