### PR TITLE
Improvement: Upload UX

### DIFF
--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -944,7 +944,7 @@ export default function MainFiles(
         {uploadError.value
           ? (
             <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
-              Upload failed — {uploadError.value}
+              Upload failed {uploadError.value}
             </span>
           )
           : null}

--- a/components/files/MainFiles.tsx
+++ b/components/files/MainFiles.tsx
@@ -927,7 +927,7 @@ export default function MainFiles(
             ? (
               <>
                 <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />
-                {uploadProgress.value || 'Uploading...'}
+                <span class='truncate min-w-0'>{uploadProgress.value || 'Uploading...'}</span>
               </>
             )
             : null}

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -79,10 +79,22 @@ export function useUploadQueue(
       }
     };
 
+    // Only sent once on mount otherwise: a STATE broadcast the SW sent while this tab was backgrounded or bfcache-frozen never arrives, so isUploading/uploadProgress get stuck at whatever they were when the tab lost focus. Re-querying on visibility/pageshow self-heals from the SW's authoritative state.
+    function resyncState() {
+      if (document.visibilityState === 'visible') {
+        postToUploadServiceWorker({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });
+      }
+    }
+
+    document.addEventListener('visibilitychange', resyncState);
+    window.addEventListener('pageshow', resyncState);
+
     postToUploadServiceWorker({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });
 
     return () => {
       uploadChannel.close();
+      document.removeEventListener('visibilitychange', resyncState);
+      window.removeEventListener('pageshow', resyncState);
     };
   }, []);
 

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -213,7 +213,7 @@ export function useUploadQueue(
 
     const itemsToUpload = items.filter((item) => {
       if (existingNamesByParentPath.get(item.parentPath)?.has(item.file.name)) {
-        uploadError.value = `${item.file.name}: A file with this name already exists.`;
+        uploadError.value = `(${item.file.name}): A file with this name already exists.`;
         return false;
       }
 
@@ -245,7 +245,7 @@ export function useUploadQueue(
         }
       } catch (error) {
         console.error(error);
-        uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
+        uploadError.value = `(${item.file.name}): ${error instanceof Error ? error.message : String(error)}`;
       }
     }
 

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -79,7 +79,7 @@ export function useUploadQueue(
       }
     };
 
-    // Only sent once on mount otherwise: a STATE broadcast the SW sent while this tab was backgrounded or bfcache-frozen never arrives, so isUploading/uploadProgress get stuck at whatever they were when the tab lost focus. Re-querying on visibility/pageshow self-heals from the SW's authoritative state.
+    // Prevents isUploading/uploadProgress from getting stuck
     function resyncState() {
       if (document.visibilityState === 'visible') {
         postToUploadServiceWorker({ type: 'QUERY_STATE', sessionTag: uploadSessionTag });

--- a/components/files/useUploadQueue.ts
+++ b/components/files/useUploadQueue.ts
@@ -113,13 +113,13 @@ export function useUploadQueue(
     directories.value = [...result.newDirectories];
   }
 
-  async function uploadFileChunked(file: File, parentPath: string, pathInView: string) {
+  async function uploadFileChunked(file: File, parentPath: string, pathInView: string, itemLabel: string) {
     const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
     const uploadId = crypto.randomUUID();
 
     try {
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-        uploadProgress.value = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+        uploadProgress.value = `${itemLabel}, chunk ${chunkIndex + 1}/${totalChunks}…`;
 
         const start = chunkIndex * CHUNK_SIZE_BYTES;
         const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
@@ -236,10 +236,15 @@ export function useUploadQueue(
     }
 
     // Fallback for browsers/contexts without an active service worker: upload directly, as before.
-    for (const item of itemsToUpload) {
+    for (const [index, item] of itemsToUpload.entries()) {
+      const itemLabel = itemsToUpload.length > 1
+        ? `Uploading ${item.file.name} (${index + 1}/${itemsToUpload.length})`
+        : `Uploading ${item.file.name}`;
+      uploadProgress.value = `${itemLabel}…`;
+
       try {
         if (item.file.size >= CHUNK_SIZE_BYTES) {
-          await uploadFileChunked(item.file, item.parentPath, pathInView);
+          await uploadFileChunked(item.file, item.parentPath, pathInView, itemLabel);
         } else {
           await uploadFileSingle(item.file, item.parentPath, pathInView);
         }

--- a/components/notes/MainNotes.tsx
+++ b/components/notes/MainNotes.tsx
@@ -301,7 +301,7 @@ export default function MainNotes({ initialDirectories, initialFiles, initialPat
         {createNoteError.value
           ? (
             <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
-              Creating the note failed — {createNoteError.value}
+              Creating the note failed {createNoteError.value}
             </span>
           )
           : null}

--- a/components/photos/MainPhotos.tsx
+++ b/components/photos/MainPhotos.tsx
@@ -200,7 +200,7 @@ export default function MainPhotos(
             ? (
               <>
                 <img src='/public/images/loading.svg' class='white mr-2' width={18} height={18} />
-                {uploadProgress.value || 'Uploading...'}
+                <span class='truncate min-w-0'>{uploadProgress.value || 'Uploading...'}</span>
               </>
             )
             : null}

--- a/components/photos/MainPhotos.tsx
+++ b/components/photos/MainPhotos.tsx
@@ -210,7 +210,7 @@ export default function MainPhotos(
         {uploadError.value
           ? (
             <span class='flex justify-end items-center text-sm mt-1 mx-2 text-red-400'>
-              Upload failed — {uploadError.value}
+              Upload failed {uploadError.value}
             </span>
           )
           : null}

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -683,7 +683,7 @@ export default function MainFiles({
     height: 18
   }), "Updating...") : null, !isDeleting.value && !isAdding.value && !isUploading.value && !isUpdating.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
     class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
-  }, "Upload failed \u2014 ", uploadError.value) : null), !fileShareId ? h("section", {
+  }, "Upload failed ", uploadError.value) : null), !fileShareId ? h("section", {
     class: "flex flex-row items-center justify-start my-12"
   }, h("span", {
     class: "font-semibold"

--- a/public/components/files/MainFiles.js
+++ b/public/components/files/MainFiles.js
@@ -676,7 +676,9 @@ export default function MainFiles({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), uploadProgress.value || 'Uploading...') : null, isUpdating.value ? h(Fragment, null, h("img", {
+  }), h("span", {
+    class: "truncate min-w-0"
+  }, uploadProgress.value || 'Uploading...')) : null, isUpdating.value ? h(Fragment, null, h("img", {
     src: "/public/images/loading.svg",
     class: "white mr-2",
     width: 18,

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -68,12 +68,12 @@ export function useUploadQueue({
     files.value = [...result.newFiles];
     directories.value = [...result.newDirectories];
   }
-  async function uploadFileChunked(file, parentPath, pathInView) {
+  async function uploadFileChunked(file, parentPath, pathInView, itemLabel) {
     const totalChunks = Math.ceil(file.size / CHUNK_SIZE_BYTES);
     const uploadId = crypto.randomUUID();
     try {
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-        uploadProgress.value = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+        uploadProgress.value = `${itemLabel}, chunk ${chunkIndex + 1}/${totalChunks}…`;
         const start = chunkIndex * CHUNK_SIZE_BYTES;
         const end = Math.min(start + CHUNK_SIZE_BYTES, file.size);
         const chunkBlob = file.slice(start, end);
@@ -166,10 +166,12 @@ export function useUploadQueue({
     if (wasEnqueuedInServiceWorker) {
       return;
     }
-    for (const item of itemsToUpload) {
+    for (const [index, item] of itemsToUpload.entries()) {
+      const itemLabel = itemsToUpload.length > 1 ? `Uploading ${item.file.name} (${index + 1}/${itemsToUpload.length})` : `Uploading ${item.file.name}`;
+      uploadProgress.value = `${itemLabel}…`;
       try {
         if (item.file.size >= CHUNK_SIZE_BYTES) {
-          await uploadFileChunked(item.file, item.parentPath, pathInView);
+          await uploadFileChunked(item.file, item.parentPath, pathInView, itemLabel);
         } else {
           await uploadFileSingle(item.file, item.parentPath, pathInView);
         }

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -39,12 +39,24 @@ export function useUploadQueue({
         directories.value = [...state.newDirectories];
       }
     };
+    function resyncState() {
+      if (document.visibilityState === 'visible') {
+        postToUploadServiceWorker({
+          type: 'QUERY_STATE',
+          sessionTag: uploadSessionTag
+        });
+      }
+    }
+    document.addEventListener('visibilitychange', resyncState);
+    window.addEventListener('pageshow', resyncState);
     postToUploadServiceWorker({
       type: 'QUERY_STATE',
       sessionTag: uploadSessionTag
     });
     return () => {
       uploadChannel.close();
+      document.removeEventListener('visibilitychange', resyncState);
+      window.removeEventListener('pageshow', resyncState);
     };
   }, []);
   async function uploadFileSingle(file, parentPath, pathInView) {

--- a/public/components/files/useUploadQueue.js
+++ b/public/components/files/useUploadQueue.js
@@ -145,7 +145,7 @@ export function useUploadQueue({
     const existingNamesByParentPath = new Map(await Promise.all(uniqueParentPaths.map(async parentPath => [parentPath, await findExistingNames(parentPath)])));
     const itemsToUpload = items.filter(item => {
       if (existingNamesByParentPath.get(item.parentPath)?.has(item.file.name)) {
-        uploadError.value = `${item.file.name}: A file with this name already exists.`;
+        uploadError.value = `(${item.file.name}): A file with this name already exists.`;
         return false;
       }
       return true;
@@ -175,7 +175,7 @@ export function useUploadQueue({
         }
       } catch (error) {
         console.error(error);
-        uploadError.value = `${item.file.name}: ${error instanceof Error ? error.message : String(error)}`;
+        uploadError.value = `(${item.file.name}): ${error instanceof Error ? error.message : String(error)}`;
       }
     }
     isUploading.value = false;

--- a/public/components/notes/MainNotes.js
+++ b/public/components/notes/MainNotes.js
@@ -224,7 +224,7 @@ export default function MainNotes({
     height: 18
   }), "Creating...") : null, !isDeleting.value && !isAdding.value && !isCreatingNote.value ? h(Fragment, null, "\xA0") : null), createNoteError.value ? h("span", {
     class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
-  }, "Creating the note failed \u2014 ", createNoteError.value) : null), h(CreateDirectoryModal, {
+  }, "Creating the note failed ", createNoteError.value) : null), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -152,7 +152,9 @@ export default function MainPhotos({
     class: "white mr-2",
     width: 18,
     height: 18
-  }), uploadProgress.value || 'Uploading...') : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
+  }), h("span", {
+    class: "truncate min-w-0"
+  }, uploadProgress.value || 'Uploading...')) : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
     class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
   }, "Upload failed ", uploadError.value) : null), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,

--- a/public/components/photos/MainPhotos.js
+++ b/public/components/photos/MainPhotos.js
@@ -154,7 +154,7 @@ export default function MainPhotos({
     height: 18
   }), uploadProgress.value || 'Uploading...') : null, !isAdding.value && !isUploading.value ? h(Fragment, null, "\xA0") : null), uploadError.value ? h("span", {
     class: "flex justify-end items-center text-sm mt-1 mx-2 text-red-400"
-  }, "Upload failed \u2014 ", uploadError.value) : null), h(CreateDirectoryModal, {
+  }, "Upload failed ", uploadError.value) : null), h(CreateDirectoryModal, {
     isOpen: isNewDirectoryModalOpen.value,
     onClickSave: onClickSaveDirectory,
     onClose: onCloseCreateDirectory

--- a/public/sw.js
+++ b/public/sw.js
@@ -28,6 +28,7 @@ function broadcastState(extra = {}) {
     sessionTag: currentJob?.sessionTag || '',
     kindsInProgress: getKindsInProgress(currentJob),
     kind: currentJob?.currentItemKind || '',
+    error: currentJob?.error || '',
     ...extra,
   });
 }
@@ -245,9 +246,10 @@ async function processQueue(job) {
         const droppedCount = job.queue.length + 1;
 
         console.error(error);
-        broadcastState({
-          error: `(${file.name}): ${error.message} (${droppedCount} upload${droppedCount === 1 ? '' : 's'} dropped).`,
-        });
+        job.error = `(${file.name}): ${error.message} (${droppedCount} upload${
+          droppedCount === 1 ? '' : 's'
+        } dropped).`;
+        broadcastState();
         await abandonCurrentJob();
 
         return;
@@ -255,7 +257,8 @@ async function processQueue(job) {
 
       console.error(error);
       await cleanupAbortedChunkUpload(job);
-      broadcastState({ error: `(${file.name}): ${String(error?.message || error)}` });
+      job.error = `(${file.name}): ${String(error?.message || error)}`;
+      broadcastState();
     }
   }
 
@@ -295,6 +298,7 @@ self.addEventListener('message', (event) => {
       currentJob = {
         queue: [],
         uploadProgress: '',
+        error: '',
         sessionTag: message.sessionTag,
         abortController: new AbortController(),
         totalCount: 0,

--- a/public/sw.js
+++ b/public/sw.js
@@ -169,7 +169,7 @@ async function uploadFileChunked(job, file, parentPath, pathInView) {
     const itemNumber = job.totalCount - job.queue.length;
     job.uploadProgress = job.totalCount > 1
       ? `Uploading ${file.name} (${itemNumber}/${job.totalCount}), chunk ${chunkIndex + 1}/${totalChunks}…`
-      : `Uploading ${file.name} (chunk ${chunkIndex + 1}/${totalChunks})…`;
+      : `Uploading ${file.name}, chunk ${chunkIndex + 1}/${totalChunks}…`;
     broadcastState();
 
     const start = chunkIndex * CHUNK_SIZE_BYTES;

--- a/public/sw.js
+++ b/public/sw.js
@@ -69,7 +69,11 @@ function isUnderDeletedPath(parentPath, deletedPath) {
 // Drops queued items that would land in the directory that just got deleted (or a subdirectory of it), without touching queued items for anywhere else. If the in-flight item is affected, only that fetch is aborted: replace the job AbortController so later items can still run.
 function handleDirectoryDeleted(job, deletedPath) {
   const currentAffected = isUnderDeletedPath(job.currentItemParentPath, deletedPath);
+  const queueLengthBefore = job.queue.length;
   job.queue = job.queue.filter((item) => !isUnderDeletedPath(item.parentPath, deletedPath));
+
+  const removedCount = queueLengthBefore - job.queue.length + (currentAffected ? 1 : 0);
+  job.totalCount = Math.max(0, job.totalCount - removedCount);
 
   if (currentAffected) {
     job.currentItemCancelled = true;
@@ -306,7 +310,6 @@ self.addEventListener('message', (event) => {
     }
 
     currentJob.queue.push(...message.items);
-    // Grows the batch total when more items are enqueued mid-flight (e.g. a directory walk that streams in), so the "(i/n)" counter stays accurate instead of resetting to the newly-added items alone.
     currentJob.totalCount += message.items.length;
 
     broadcastState();

--- a/public/sw.js
+++ b/public/sw.js
@@ -246,7 +246,7 @@ async function processQueue(job) {
 
         console.error(error);
         broadcastState({
-          error: `${file.name}: ${error.message} (${droppedCount} upload${droppedCount === 1 ? '' : 's'} dropped).`,
+          error: `(${file.name}): ${error.message} (${droppedCount} upload${droppedCount === 1 ? '' : 's'} dropped).`,
         });
         await abandonCurrentJob();
 
@@ -255,7 +255,7 @@ async function processQueue(job) {
 
       console.error(error);
       await cleanupAbortedChunkUpload(job);
-      broadcastState({ error: `${file.name}: ${String(error?.message || error)}` });
+      broadcastState({ error: `(${file.name}): ${String(error?.message || error)}` });
     }
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -7,7 +7,7 @@ const REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 
 const broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
 
-let currentJob = null; // { queue: [{ file, parentPath, pathInView }], uploadProgress, sessionTag, abortController }
+let currentJob = null; // { queue: [{ file, parentPath, pathInView }], uploadProgress, sessionTag, abortController, totalCount }
 
 // A queue outlives the session that created it, so the upload endpoints refuse requests tagged with a session other than the one their cookie now belongs to. When that happens there's nothing left to retry: the rest of the queue is dropped instead of being uploaded as whoever is logged in now.
 class UploadSessionGoneError extends Error {}
@@ -166,7 +166,10 @@ async function uploadFileChunked(job, file, parentPath, pathInView) {
       throw new Error('upload cancelled');
     }
 
-    job.uploadProgress = `Uploading ${file.name} (${chunkIndex + 1}/${totalChunks})…`;
+    const itemNumber = job.totalCount - job.queue.length;
+    job.uploadProgress = job.totalCount > 1
+      ? `Uploading ${file.name} (${itemNumber}/${job.totalCount}), chunk ${chunkIndex + 1}/${totalChunks}…`
+      : `Uploading ${file.name} (chunk ${chunkIndex + 1}/${totalChunks})…`;
     broadcastState();
 
     const start = chunkIndex * CHUNK_SIZE_BYTES;
@@ -211,7 +214,8 @@ async function processQueue(job) {
   while (job.queue.length > 0) {
     const { file, parentPath, pathInView, kind } = job.queue.shift();
 
-    job.uploadProgress = '';
+    const itemNumber = job.totalCount - job.queue.length;
+    job.uploadProgress = job.totalCount > 1 ? `Uploading ${file.name} (${itemNumber}/${job.totalCount})…` : '';
     job.currentItemKind = kind || 'file';
     job.currentItemParentPath = parentPath;
     job.currentUploadId = undefined;
@@ -293,10 +297,13 @@ self.addEventListener('message', (event) => {
         uploadProgress: '',
         sessionTag: message.sessionTag,
         abortController: new AbortController(),
+        totalCount: 0,
       };
     }
 
     currentJob.queue.push(...message.items);
+    // Grows the batch total when more items are enqueued mid-flight (e.g. a directory walk that streams in), so the "(i/n)" counter stays accurate instead of resetting to the newly-added items alone.
+    currentJob.totalCount += message.items.length;
 
     broadcastState();
 

--- a/public/ts/service-worker.ts
+++ b/public/ts/service-worker.ts
@@ -7,7 +7,10 @@ export async function registerUploadServiceWorker() {
   }
 
   try {
-    uploadServiceWorkerRegistration = await navigator.serviceWorker.register('/public/sw.js', { scope: '/' });
+    uploadServiceWorkerRegistration = await navigator.serviceWorker.register('/public/sw.js', {
+      scope: '/',
+      updateViaCache: 'none',
+    });
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Upload progress/UX polish on top of the chunked-upload service worker.

- Batch uploads now show file-count progress (`Uploading foo.jpg (2/5)…`), with per-chunk detail folded in for large files
- `sw.js` registered with `updateViaCache: 'none'` so the browser always re-fetches it on update, instead of serving a stale cached worker
- Resync upload state on `visibilitychange`/`pageshow`: a SW state broadcast sent while the tab was backgrounded/bfcache-frozen never arrives, so the "Uploading…" label could get stuck; re-querying on tab-visible/resume self-heals from the SW's authoritative state
- Upload error string format changed to `(filename): message`

## Testing

This is testable using the `ghcr.io/medallyon/bewcloud:upload-progress-ux` docker image.